### PR TITLE
Shorten keyword in crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ edition         = "2021"
 license         = "Apache-2.0"
 repository      = "https://github.com/contextgeneric/cgp"
 authors         = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+keywords        = ["cgp"]
 
 [patch.crates-io]
 cgp                         = { path = "./crates/cgp" }

--- a/crates/cgp-async-macro/Cargo.toml
+++ b/crates/cgp-async-macro/Cargo.toml
@@ -6,7 +6,7 @@ repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
 version      = "0.1.0"
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming async macros
 """

--- a/crates/cgp-async/Cargo.toml
+++ b/crates/cgp-async/Cargo.toml
@@ -6,9 +6,9 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
-    Async-generic primitives to support both sync/async in Context-generic programming
+    Async-generic primitives to support both sync/async in context-generic programming
 """
 
 [dependencies]

--- a/crates/cgp-component-macro-lib/Cargo.toml
+++ b/crates/cgp-component-macro-lib/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming core component macros implemented as a library.
 """

--- a/crates/cgp-component-macro/Cargo.toml
+++ b/crates/cgp-component-macro/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming core component macros
 """

--- a/crates/cgp-component/Cargo.toml
+++ b/crates/cgp-component/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming core component traits
 """

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming core traits
 """

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming error handlers implemented using eyre
 """

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming error handlers implemented using `std::error::Error`
 """

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming error components
 """

--- a/crates/cgp-extra/Cargo.toml
+++ b/crates/cgp-extra/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming extra meta-crate
 """

--- a/crates/cgp-field-macro-lib/Cargo.toml
+++ b/crates/cgp-field-macro-lib/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming field macros as a library
 """

--- a/crates/cgp-field-macro/Cargo.toml
+++ b/crates/cgp-field-macro/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming field macros
 """

--- a/crates/cgp-field/Cargo.toml
+++ b/crates/cgp-field/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming field traits
 """

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming inner component
 """

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming runner component
 """

--- a/crates/cgp-sync/Cargo.toml
+++ b/crates/cgp-sync/Cargo.toml
@@ -6,9 +6,9 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
-    Async-generic primitives to support both sync/async in Context-generic programming
+    Async-generic primitives to support both sync/async in context-generic programming
 """
 
 [dependencies]

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -6,7 +6,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-keywords     = ["context-generic programming"]
+keywords     = { workspace = true }
 description  = """
     Context-generic programming meta crate
 """


### PR DESCRIPTION
Crates.io only allows keywords with 20 charaters or less.