### PR TITLE
Support async-generic feature flags in cgp-async

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,11 @@ jobs:
           name: clippy-all-features
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+      - uses: actions-rs/clippy-check@v1
+        with:
+          name: clippy-no-default-features
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --no-default-features --all-targets -- -D warnings
 
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 ## Pre-Release
 
-- Introduce new cgp-field constructs [#36](https://github.com/contextgeneric/cgp/pull/36)
+- Support async-generic feature flags in cgp-async - [#37](https://github.com/contextgeneric/cgp/pull/37)
+    - Introduce the following feature flags to `cgp-async`:
+    - `async`
+    - `send`
+    - `sync`
+    - `static`
+    - `full` - default feature with all enabled
+    - Introduce the following traits in `cgp-async`:
+    - `MaybeSend` - alias to `Send` when the `send` feature is enabled, otherwise nothing.
+    - `MaybeSync` - alias to `Sync` when the `sync` feature is enabled, otherwise nothing.
+    - `MaybeStatic` - alias to `'static` when the `static` feature is enabled, otherwise nothing.
+    - Update the `Async` trait from `Sized + Send + Sync + 'static` to `MaybeSend + MaybeSync + MaybeStatic`.
+    - The `Sized` constraint is removed from `Async` to allow use inside `dyn` traits.
+    - Update the `#[async_trait]` macro to desugar async functions to return `impl Future<Output: MaybeSend>`.
+    - Use of `#[async_trait]` now requires import of `cgp::prelude::*` to allow `MaybeSend` to be auto imported.
+    - `cgp-async` now re-exports `cgp_sync::strip_async` if the `async` feature is not enabled.
+    - i.e. async functions are desugared into sync functions if the `async` feature is disabled.
+    - Crates such as `cgp` and `cgp-core` offers the `full` feature, which can be disabled to disable the indirect default features in `cgp-async`.
+
+- Introduce new cgp-field constructs - [#36](https://github.com/contextgeneric/cgp/pull/36)
     - Introduce the product type constructs `Cons` and `Nil`.
     - Introduce the sum type constructs `Either` and `Void`.
     - Introduce the `Field` type for tagged field value.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ name = "cgp-async"
 version = "0.1.0"
 dependencies = [
  "cgp-async-macro",
+ "cgp-sync",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "cgp"
 version = "0.1.0"
 dependencies = [
+ "cgp-async",
  "cgp-core",
  "cgp-extra",
 ]
@@ -31,7 +32,6 @@ dependencies = [
 name = "cgp-component"
 version = "0.1.0"
 dependencies = [
- "cgp-async",
  "cgp-component-macro",
 ]
 
@@ -129,7 +129,6 @@ dependencies = [
 name = "cgp-inner"
 version = "0.1.0"
 dependencies = [
- "cgp-async",
  "cgp-component",
 ]
 

--- a/crates/cgp-async-macro/src/impl_async.rs
+++ b/crates/cgp-async-macro/src/impl_async.rs
@@ -15,7 +15,7 @@ pub fn impl_async(item: TokenStream) -> TokenStream {
                     };
 
                     let impl_return: ReturnType = parse_quote! {
-                        -> impl ::core::future::Future<Output = #return_type> + Send
+                        -> impl ::core::future::Future<Output = #return_type> + MaybeSend
                     };
 
                     trait_fn.sig.output = impl_return;

--- a/crates/cgp-async/Cargo.toml
+++ b/crates/cgp-async/Cargo.toml
@@ -11,5 +11,18 @@ description  = """
     Async-generic primitives to support both sync/async in context-generic programming
 """
 
+[features]
+default = [
+    "async",
+    "send",
+    "sync",
+    "static",
+]
+async = []
+send = [ "async" ]
+sync = [ "async" ]
+static = [ "async" ]
+
 [dependencies]
 cgp-async-macro = { version = "0.1.0" }
+cgp-sync = { version = "0.1.0" }

--- a/crates/cgp-async/Cargo.toml
+++ b/crates/cgp-async/Cargo.toml
@@ -12,7 +12,8 @@ description  = """
 """
 
 [features]
-default = [
+default = [ "full" ]
+full = [
     "async",
     "send",
     "sync",

--- a/crates/cgp-async/src/lib.rs
+++ b/crates/cgp-async/src/lib.rs
@@ -1,29 +1,9 @@
+pub mod traits;
+
+pub use traits::{Async, MaybeSend, MaybeStatic, MaybeSync};
+
+#[cfg(feature = "async")]
 pub use cgp_async_macro::native_async as async_trait;
 
-/**
-   This is defined as a convenient constraint alias to
-   `Sized + Send + Sync + 'static`.
-
-   This constraint is commonly required to be present in almost all associated
-   types. The `Sized` constraint is commonly required for associated types to be
-   used as generic parameters. The `Send + Sync + 'static` constraints are
-   important for the use of async functions inside traits.
-
-   Because Rust do not currently natively support the use of async functions
-   in traits, we use the [`async_trait`] crate to desugar async functions
-   inside traits into functions returning
-   `Pin<Box<dyn Future + Send>>`. Due to the additional `Send` and lifetime
-   trait bounds inside the returned boxed future, almost all values that are
-   used inside the async functions are required to have types that implement
-   `Send` and `Sync`.
-
-   It is also common to require the associated types to have the `'static`
-   lifetime for them to be used inside async functions, because Rust would
-   otherwise infer a more restrictive lifetime that does not outlive the
-   async functions. The `'static` lifetime constraint here really means
-   that the types implementing `Async` must not contain any lifetime
-   parameter.
-*/
-pub trait Async: Send + Sync + 'static {}
-
-impl<A> Async for A where A: Send + Sync + 'static {}
+#[cfg(not(feature = "async"))]
+pub use cgp_sync::async_trait;

--- a/crates/cgp-async/src/traits/async.rs
+++ b/crates/cgp-async/src/traits/async.rs
@@ -1,0 +1,31 @@
+use crate::traits::r#static::MaybeStatic;
+use crate::traits::send::MaybeSend;
+use crate::traits::sync::MaybeSync;
+
+/**
+   This is defined as a convenient constraint alias to
+   `Sized + Send + Sync + 'static`.
+
+   This constraint is commonly required to be present in almost all associated
+   types. The `Sized` constraint is commonly required for associated types to be
+   used as generic parameters. The `Send + Sync + 'static` constraints are
+   important for the use of async functions inside traits.
+
+   Because Rust do not currently natively support the use of async functions
+   in traits, we use the [`async_trait`] crate to desugar async functions
+   inside traits into functions returning
+   `Pin<Box<dyn Future + Send>>`. Due to the additional `Send` and lifetime
+   trait bounds inside the returned boxed future, almost all values that are
+   used inside the async functions are required to have types that implement
+   `Send` and `Sync`.
+
+   It is also common to require the associated types to have the `'static`
+   lifetime for them to be used inside async functions, because Rust would
+   otherwise infer a more restrictive lifetime that does not outlive the
+   async functions. The `'static` lifetime constraint here really means
+   that the types implementing `Async` must not contain any lifetime
+   parameter.
+*/
+pub trait Async: MaybeSend + MaybeSync + MaybeStatic {}
+
+impl<A> Async for A where A: MaybeSend + MaybeSync + MaybeStatic {}

--- a/crates/cgp-async/src/traits/mod.rs
+++ b/crates/cgp-async/src/traits/mod.rs
@@ -1,0 +1,9 @@
+pub mod r#async;
+pub mod send;
+pub mod r#static;
+pub mod sync;
+
+pub use r#async::Async;
+pub use r#static::MaybeStatic;
+pub use send::MaybeSend;
+pub use sync::MaybeSync;

--- a/crates/cgp-async/src/traits/send.rs
+++ b/crates/cgp-async/src/traits/send.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "send")]
+pub use core::marker::Send as MaybeSend;
+
+#[cfg(not(feature = "send"))]
+pub trait MaybeSend {}
+
+#[cfg(not(feature = "send"))]
+impl<T> MaybeSend for T {}

--- a/crates/cgp-async/src/traits/static.rs
+++ b/crates/cgp-async/src/traits/static.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "static")]
+pub trait MaybeStatic: 'static {}
+
+#[cfg(feature = "static")]
+impl<T: 'static> MaybeStatic for T {}
+
+#[cfg(not(feature = "static"))]
+pub trait MaybeStatic {}
+
+#[cfg(not(feature = "static"))]
+impl<T> MaybeStatic for T {}

--- a/crates/cgp-async/src/traits/sync.rs
+++ b/crates/cgp-async/src/traits/sync.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "sync")]
+pub use core::marker::Sync as MaybeSync;
+
+#[cfg(not(feature = "sync"))]
+pub trait MaybeSync {}
+
+#[cfg(not(feature = "sync"))]
+impl<T> MaybeSync for T {}

--- a/crates/cgp-component/Cargo.toml
+++ b/crates/cgp-component/Cargo.toml
@@ -12,5 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-async = { version = "0.1.0" }
 cgp-component-macro = { version = "0.1.0" }

--- a/crates/cgp-component/src/traits/mod.rs
+++ b/crates/cgp-component/src/traits/mod.rs
@@ -1,6 +1,5 @@
 pub mod delegate_component;
 pub mod has_components;
-pub mod sync;
 
 pub use delegate_component::DelegateComponent;
 pub use has_components::HasComponents;

--- a/crates/cgp-component/src/traits/sync.rs
+++ b/crates/cgp-component/src/traits/sync.rs
@@ -1,1 +1,0 @@
-pub use cgp_async::Async;

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -11,8 +11,11 @@ description  = """
     Context-generic programming core traits
 """
 
+[features]
+default = [ "cgp-async/full" ]
+
 [dependencies]
-cgp-async       = { version = "0.1.0" }
+cgp-async       = { version = "0.1.0", default-features = false }
 cgp-component   = { version = "0.1.0" }
 cgp-type        = { version = "0.1.0" }
 cgp-error       = { version = "0.1.0" }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -12,7 +12,8 @@ description  = """
 """
 
 [features]
-default = [ "cgp-async/full" ]
+default = [ "full" ]
+full = [ "cgp-async/full" ]
 
 [dependencies]
 cgp-async       = { version = "0.1.0", default-features = false }

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use cgp_async::{async_trait, Async};
+pub use cgp_async::{async_trait, Async, MaybeSend, MaybeStatic, MaybeSync};
 pub use cgp_component::{
     define_components, delegate_components, derive_component, DelegateComponent, HasComponents,
 };

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.1.0" }
+cgp-core    = { version = "0.1.0", default-features = false }
 eyre        = { version = "0.6.11" }

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.1.0", default-features = false }
+cgp-core    = { version = "0.1.0" }
 eyre        = { version = "0.6.11" }

--- a/crates/cgp-error-eyre/src/lib.rs
+++ b/crates/cgp-error-eyre/src/lib.rs
@@ -7,10 +7,7 @@ use eyre::{eyre, Report};
 
 pub struct ProvideEyreError;
 
-impl<Context> ProvideErrorType<Context> for ProvideEyreError
-where
-    Context: Async,
-{
+impl<Context> ProvideErrorType<Context> for ProvideEyreError {
     type Error = Report;
 }
 
@@ -19,7 +16,7 @@ pub struct RaiseStdError;
 impl<Context, E> ErrorRaiser<Context, E> for RaiseStdError
 where
     Context: HasErrorType<Error = Report>,
-    E: StdError + Async,
+    E: StdError + Send + Sync + 'static,
 {
     fn raise_error(e: E) -> Report {
         e.into()

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.1.0" }
+cgp-core    = { version = "0.1.0", default-features = false }

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -12,6 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-async       = { version = "0.1.0" }
+cgp-async       = { version = "0.1.0", default-features = false }
 cgp-component   = { version = "0.1.0" }
 cgp-type        = { version = "0.1.0" }

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -12,5 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-async = { version = "0.1.0" }
 cgp-component = { version = "0.1.0" }

--- a/crates/cgp-inner/src/lib.rs
+++ b/crates/cgp-inner/src/lib.rs
@@ -2,12 +2,11 @@
 
 extern crate alloc;
 
-use cgp_async::Async;
 use cgp_component::{derive_component, DelegateComponent, HasComponents};
 
 #[derive_component(InnerComponent, ProvideInner<Context>)]
-pub trait HasInner: Async {
-    type Inner: Async;
+pub trait HasInner {
+    type Inner;
 
     fn inner(&self) -> &Self::Inner;
 }

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -12,6 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-async = { version = "0.1.0" }
+cgp-async = { version = "0.1.0", default-features = false }
 cgp-error = { version = "0.1.0" }
 cgp-component = { version = "0.1.0" }

--- a/crates/cgp-run/src/lib.rs
+++ b/crates/cgp-run/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 #[allow(unused_imports)]
 use alloc::boxed::Box;
 
-use cgp_async::{async_trait, Async};
+use cgp_async::{async_trait, Async, MaybeSend};
 use cgp_component::{derive_component, DelegateComponent, HasComponents};
 use cgp_error::HasErrorType;
 

--- a/crates/cgp-run/src/lib.rs
+++ b/crates/cgp-run/src/lib.rs
@@ -5,8 +5,8 @@ extern crate alloc;
 #[allow(unused_imports)]
 use alloc::boxed::Box;
 
-use cgp_async::{async_trait, Async, MaybeSend};
-use cgp_component::{derive_component, DelegateComponent, HasComponents};
+use cgp_async::*;
+use cgp_component::*;
 use cgp_error::HasErrorType;
 
 #[derive_component(RunnerComponent, Runner<Context>)]

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -11,6 +11,10 @@ description  = """
     Context-generic programming meta crate
 """
 
+[features]
+default = [ "cgp-async/full" ]
+
 [dependencies]
-cgp-core       = { version = "0.1.0" }
+cgp-async      = { version = "0.1.0", default-features = false }
+cgp-core       = { version = "0.1.0", default-features = false }
 cgp-extra      = { version = "0.1.0" }

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -12,7 +12,8 @@ description  = """
 """
 
 [features]
-default = [ "cgp-async/full" ]
+default = [ "full" ]
+full = [ "cgp-async/full" ]
 
 [dependencies]
 cgp-async      = { version = "0.1.0", default-features = false }


### PR DESCRIPTION
- Introduce the following feature flags to `cgp-async`:
  - `async`
  - `send`
  - `sync`
  - `static`
  - `full` - default feature with all enabled
- Introduce the following traits in `cgp-async`:
  - `MaybeSend` - alias to `Send` when the `send` feature is enabled, otherwise nothing.
  - `MaybeSync` - alias to `Sync` when the `sync` feature is enabled, otherwise nothing.
  - `MaybeStatic` - alias to `'static` when the `static` feature is enabled, otherwise nothing.
- Update the `Async` trait from `Sized + Send + Sync + 'static` to `MaybeSend + MaybeSync + MaybeStatic`.
  - The `Sized` constraint is removed from `Async` to allow use inside `dyn` traits.
- Update the `#[async_trait]` macro to desugar async functions to return `impl Future<Output: MaybeSend>`.
  - Use of `#[async_trait]` now requires import of `cgp::prelude::*` to allow `MaybeSend` to be auto imported.
- `cgp-async` now re-exports `cgp_sync::strip_async` if the `async` feature is not enabled.
  - i.e. async functions are desugared into sync functions if the `async` feature is disabled.
- Crates such as `cgp` and `cgp-core` offers the `full` feature, which can be disabled to disable the indirect default features in `cgp-async`.