### PR TITLE
Prepare for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Pre-Release
+## v0.2.0 (2025-12-08)
 
 - Rename `define_components!` to `cgp_preset!` with slight improvement - [#41](https://github.com/contextgeneric/cgp/pull/41)
     - Introduce `replace_with!` macro that allows replacement of an identifier with a list of component types in the body.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cgp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-async"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-async-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -30,14 +30,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-component"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-component-macro",
 ]
 
 [[package]]
 name = "cgp-component-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-component-macro-lib",
  "proc-macro2",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-component-macro-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-error"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-eyre"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-core",
  "eyre",
@@ -85,21 +85,21 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-std"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-extra"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-run",
 ]
 
 [[package]]
 name = "cgp-field"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-component",
  "cgp-field-macro",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-field-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-field-macro-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -127,14 +127,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-inner"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-component",
 ]
 
 [[package]]
 name = "cgp-run"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -143,14 +143,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-sync"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-async-macro",
 ]
 
 [[package]]
 name = "cgp-type"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cgp-component",
 ]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 
 # `cgp` - Context-Generic Programming Libraries in Rust
 
-[![Apache 2.0 Licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/informalsystems/cgp/blob/master/LICENSE)
+[![Apache 2.0 Licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/contextgeneric/cgp/blob/master/LICENSE)
+[![Crates.io](https://img.shields.io/crates/v/cgp.svg)](https://crates.io/crates/cgp)
 ![Rust Stable](https://img.shields.io/badge/rustc-stable-blue.svg)
-![Rust 1.79+](https://img.shields.io/badge/rustc-1.79+-blue.svg)
+![Rust 1.81+](https://img.shields.io/badge/rustc-1.81+-blue.svg)
 
 ## Overview
 
-The `cgp` project contains a collection of micro Rust crates that empowers 
-_context-generic programming_ (CGP), a new programming paradigm in Rust.
-To learn more about context-generic programming, check out the book
-[Context-Generic Programming Patterns](https://patterns.contextgeneric.dev/).
+The `cgp` project contains a collection of micro Rust crates that empowers
+_context-generic programming_ (CGP), a new modular programming paradigm in Rust.
+To learn more about context-generic programming, check out the
+our website [contextgeneric.dev](https://contextgeneric.dev/), and
+our book [Context-Generic Programming Patterns](https://patterns.contextgeneric.dev/).
 
 ## Crates Organization
 
 The CGP core constructs are organized as many child crates that are intended
-to be minimal and stable. Having each construct defined in separate crate 
-helps us avoid introducing breaking changes in semantic  versioning, in case 
+to be minimal and stable. Having each construct defined in separate crate
+helps us avoid introducing breaking changes in semantic  versioning, in case
 an unrelated construct is updated.
 
 We also offers meta-crates that aggregate the dependencies from many CGP
-child crates into one place, so that users can use CGP by specifying only one 
+child crates into one place, so that users can use CGP by specifying only one
 dependency:
 
 - [`cgp`](./crates/cgp/) - The main crate that includes all child crates defined in this project.

--- a/crates/cgp-async-macro/Cargo.toml
+++ b/crates/cgp-async-macro/Cargo.toml
@@ -5,7 +5,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.1.0"
+version      = "0.2.0"
 keywords     = { workspace = true }
 description  = """
     Context-generic programming async macros

--- a/crates/cgp-async/Cargo.toml
+++ b/crates/cgp-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-async"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -25,5 +25,5 @@ sync = [ "async" ]
 static = [ "async" ]
 
 [dependencies]
-cgp-async-macro = { version = "0.1.0" }
-cgp-sync = { version = "0.1.0" }
+cgp-async-macro = { version = "0.2.0" }
+cgp-sync = { version = "0.2.0" }

--- a/crates/cgp-component-macro-lib/Cargo.toml
+++ b/crates/cgp-component-macro-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component-macro-lib"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-component-macro/Cargo.toml
+++ b/crates/cgp-component-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component-macro"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -15,5 +15,5 @@ description  = """
 proc-macro = true
 
 [dependencies]
-cgp-component-macro-lib = { version = "0.1.0" }
+cgp-component-macro-lib = { version = "0.2.0" }
 proc-macro2     = "1.0.67"

--- a/crates/cgp-component/Cargo.toml
+++ b/crates/cgp-component/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-component-macro = { version = "0.1.0" }
+cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-core"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -16,9 +16,9 @@ default = [ "full" ]
 full = [ "cgp-async/full" ]
 
 [dependencies]
-cgp-async       = { version = "0.1.0", default-features = false }
-cgp-component   = { version = "0.1.0" }
-cgp-type        = { version = "0.1.0" }
-cgp-error       = { version = "0.1.0" }
-cgp-field       = { version = "0.1.0" }
-cgp-inner       = { version = "0.1.0" }
+cgp-async       = { version = "0.2.0", default-features = false }
+cgp-component   = { version = "0.2.0" }
+cgp-type        = { version = "0.2.0" }
+cgp-error       = { version = "0.2.0" }
+cgp-field       = { version = "0.2.0" }
+cgp-inner       = { version = "0.2.0" }

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-eyre"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.1.0", default-features = false }
+cgp-core    = { version = "0.2.0", default-features = false }
 eyre        = { version = "0.6.11" }

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-std"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.1.0", default-features = false }
+cgp-core    = { version = "0.2.0", default-features = false }

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,6 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-async       = { version = "0.1.0", default-features = false }
-cgp-component   = { version = "0.1.0" }
-cgp-type        = { version = "0.1.0" }
+cgp-async       = { version = "0.2.0", default-features = false }
+cgp-component   = { version = "0.2.0" }
+cgp-type        = { version = "0.2.0" }

--- a/crates/cgp-extra/Cargo.toml
+++ b/crates/cgp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-extra"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-run        = { version = "0.1.0" }
+cgp-run        = { version = "0.2.0" }

--- a/crates/cgp-field-macro-lib/Cargo.toml
+++ b/crates/cgp-field-macro-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field-macro-lib"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-field-macro/Cargo.toml
+++ b/crates/cgp-field-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field-macro"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -15,5 +15,5 @@ description  = """
 proc-macro = true
 
 [dependencies]
-cgp-field-macro-lib = { version = "0.1.0" }
+cgp-field-macro-lib = { version = "0.2.0" }
 proc-macro2     = "1.0.67"

--- a/crates/cgp-field/Cargo.toml
+++ b/crates/cgp-field/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,6 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-field-macro = { version = "0.1.0" }
-cgp-component   = { version = "0.1.0" }
-cgp-type        = { version = "0.1.0" }
+cgp-field-macro = { version = "0.2.0" }
+cgp-component   = { version = "0.2.0" }
+cgp-type        = { version = "0.2.0" }

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-inner"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-component = { version = "0.1.0" }
+cgp-component = { version = "0.2.0" }

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-run"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,6 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-async = { version = "0.1.0", default-features = false }
-cgp-error = { version = "0.1.0" }
-cgp-component = { version = "0.1.0" }
+cgp-async = { version = "0.2.0", default-features = false }
+cgp-error = { version = "0.2.0" }
+cgp-component = { version = "0.2.0" }

--- a/crates/cgp-sync/Cargo.toml
+++ b/crates/cgp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-sync"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-async-macro = { version = "0.1.0" }
+cgp-async-macro = { version = "0.2.0" }

--- a/crates/cgp-type/Cargo.toml
+++ b/crates/cgp-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-type"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-component = { version = "0.1.0" }
+cgp-component = { version = "0.2.0" }

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp"
-version      = "0.1.0"
+version      = "0.2.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -16,6 +16,6 @@ default = [ "full" ]
 full = [ "cgp-async/full" ]
 
 [dependencies]
-cgp-async      = { version = "0.1.0", default-features = false }
-cgp-core       = { version = "0.1.0", default-features = false }
-cgp-extra      = { version = "0.1.0" }
+cgp-async      = { version = "0.2.0", default-features = false }
+cgp-core       = { version = "0.2.0", default-features = false }
+cgp-extra      = { version = "0.2.0" }


### PR DESCRIPTION
The v0.2.0 release includes changes for the following PRs:

- https://github.com/contextgeneric/cgp/pull/41
- https://github.com/contextgeneric/cgp/pull/38
- https://github.com/contextgeneric/cgp/pull/37
- https://github.com/contextgeneric/cgp/pull/36
- https://github.com/contextgeneric/cgp/pull/35
- https://github.com/contextgeneric/cgp/pull/34
- https://github.com/contextgeneric/cgp/pull/24
- https://github.com/contextgeneric/cgp/pull/23