### PR TITLE
Decouple component and field macro crates from the library crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.0 (pre-release)
+
+- Decouple component and field macro crates from the library crates - [#47](https://github.com/contextgeneric/cgp/pull/47)
+    - Remove `cgp-component-macro` crate from being a dependency of `cgp-component`.
+    - Remove `cgp-field-macro` crate from being a dependency of `cgp-field`.
+
 ## v0.2.0 (2025-12-08)
 
 - Rename `define_components!` to `cgp_preset!` with slight improvement - [#41](https://github.com/contextgeneric/cgp/pull/41)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,6 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.2.0"
-dependencies = [
- "cgp-component-macro",
-]
 
 [[package]]
 name = "cgp-component-macro"
@@ -60,6 +57,7 @@ version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
+ "cgp-component-macro",
  "cgp-error",
  "cgp-field",
  "cgp-inner",
@@ -72,6 +70,7 @@ version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
+ "cgp-component-macro",
  "cgp-type",
 ]
 
@@ -130,6 +129,7 @@ name = "cgp-inner"
 version = "0.2.0"
 dependencies = [
  "cgp-component",
+ "cgp-component-macro",
 ]
 
 [[package]]
@@ -138,6 +138,7 @@ version = "0.2.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
+ "cgp-component-macro",
  "cgp-error",
 ]
 
@@ -153,6 +154,7 @@ name = "cgp-type"
 version = "0.2.0"
 dependencies = [
  "cgp-component",
+ "cgp-component-macro",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "cgp-component-macro",
  "cgp-error",
  "cgp-field",
+ "cgp-field-macro",
  "cgp-inner",
  "cgp-type",
 ]
@@ -101,7 +102,6 @@ name = "cgp-field"
 version = "0.2.0"
 dependencies = [
  "cgp-component",
- "cgp-field-macro",
  "cgp-type",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ name = "cgp-component-macro"
 version = "0.2.0"
 dependencies = [
  "cgp-component-macro-lib",
- "proc-macro2",
 ]
 
 [[package]]
@@ -224,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/cgp-async-macro/Cargo.toml
+++ b/crates/cgp-async-macro/Cargo.toml
@@ -17,6 +17,6 @@ proc-macro = true
 [features]
 
 [dependencies]
-syn = { version = "2.0.90", features = [ "full" ] }
-quote = "1.0.33"
+syn         = { version = "2.0.90", features = [ "full" ] }
+quote       = "1.0.33"
 proc-macro2 = "1.0.92"

--- a/crates/cgp-async/Cargo.toml
+++ b/crates/cgp-async/Cargo.toml
@@ -26,4 +26,4 @@ static = [ "async" ]
 
 [dependencies]
 cgp-async-macro = { version = "0.2.0" }
-cgp-sync = { version = "0.2.0" }
+cgp-sync        = { version = "0.2.0" }

--- a/crates/cgp-component-macro-lib/Cargo.toml
+++ b/crates/cgp-component-macro-lib/Cargo.toml
@@ -12,8 +12,8 @@ description  = """
 """
 
 [dependencies]
-syn = { version = "2.0.90", features = [ "full", "extra-traits" ] }
-quote = "1.0.33"
-proc-macro2 = "1.0.92"
-itertools = "0.13.0"
-prettyplease = "0.2.25"
+syn             = { version = "2.0.90", features = [ "full", "extra-traits" ] }
+quote           = "1.0.33"
+proc-macro2     = "1.0.92"
+itertools       = "0.13.0"
+prettyplease    = "0.2.25"

--- a/crates/cgp-component-macro/Cargo.toml
+++ b/crates/cgp-component-macro/Cargo.toml
@@ -16,4 +16,3 @@ proc-macro = true
 
 [dependencies]
 cgp-component-macro-lib = { version = "0.2.0" }
-proc-macro2     = "1.0.92"

--- a/crates/cgp-component/Cargo.toml
+++ b/crates/cgp-component/Cargo.toml
@@ -12,4 +12,3 @@ description  = """
 """
 
 [dependencies]
-cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-component/src/lib.rs
+++ b/crates/cgp-component/src/lib.rs
@@ -8,8 +8,5 @@
 pub mod traits;
 pub mod types;
 
-pub use cgp_component_macro::{
-    cgp_component, cgp_preset, delegate_components, for_each_replace, replace_with,
-};
 pub use traits::{DelegateComponent, HasComponents};
 pub use types::{UseContext, UseDelegate, WithContext, WithProvider};

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -16,9 +16,10 @@ default = [ "full" ]
 full = [ "cgp-async/full" ]
 
 [dependencies]
-cgp-async       = { version = "0.2.0", default-features = false }
-cgp-component   = { version = "0.2.0" }
-cgp-type        = { version = "0.2.0" }
-cgp-error       = { version = "0.2.0" }
-cgp-field       = { version = "0.2.0" }
-cgp-inner       = { version = "0.2.0" }
+cgp-async           = { version = "0.2.0", default-features = false }
+cgp-component       = { version = "0.2.0" }
+cgp-component-macro = { version = "0.2.0" }
+cgp-type            = { version = "0.2.0" }
+cgp-error           = { version = "0.2.0" }
+cgp-field           = { version = "0.2.0" }
+cgp-inner           = { version = "0.2.0" }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -22,4 +22,5 @@ cgp-component-macro = { version = "0.2.0" }
 cgp-type            = { version = "0.2.0" }
 cgp-error           = { version = "0.2.0" }
 cgp-field           = { version = "0.2.0" }
+cgp-field-macro     = { version = "0.2.0" }
 cgp-inner           = { version = "0.2.0" }

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,11 +1,8 @@
 pub use cgp_async::{async_trait, Async, MaybeSend, MaybeStatic, MaybeSync};
+pub use cgp_component::{DelegateComponent, HasComponents};
 pub use cgp_component_macro::{
     cgp_component, cgp_preset, delegate_components, for_each_replace, replace_with,
 };
-pub use cgp_component::{
-    DelegateComponent, HasComponents,
-};
 pub use cgp_error::{CanRaiseError, HasErrorType};
-pub use cgp_field::{
-    product, symbol, Char, Cons, Either, HasField, HasFieldMut, Nil, Product, Sum, Void,
-};
+pub use cgp_field::{Char, Cons, Either, HasField, HasFieldMut, Nil, Void};
+pub use cgp_field_macro::{product, symbol, HasField, Product, Sum};

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,6 +1,8 @@
 pub use cgp_async::{async_trait, Async, MaybeSend, MaybeStatic, MaybeSync};
-pub use cgp_component::{
+pub use cgp_component_macro::{
     cgp_component, cgp_preset, delegate_components, for_each_replace, replace_with,
+};
+pub use cgp_component::{
     DelegateComponent, HasComponents,
 };
 pub use cgp_error::{CanRaiseError, HasErrorType};

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.2.0", default-features = false }
+cgp-core = { version = "0.2.0", default-features = false }

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -12,6 +12,7 @@ description  = """
 """
 
 [dependencies]
-cgp-async       = { version = "0.2.0", default-features = false }
-cgp-component   = { version = "0.2.0" }
-cgp-type        = { version = "0.2.0" }
+cgp-async           = { version = "0.2.0", default-features = false }
+cgp-component       = { version = "0.2.0" }
+cgp-component-macro = { version = "0.2.0" }
+cgp-type            = { version = "0.2.0" }

--- a/crates/cgp-error/src/can_raise_error.rs
+++ b/crates/cgp-error/src/can_raise_error.rs
@@ -1,4 +1,5 @@
-use cgp_component::{cgp_component, DelegateComponent, HasComponents, UseDelegate};
+use cgp_component_macro::cgp_component;
+use cgp_component::{DelegateComponent, HasComponents, UseDelegate};
 
 use crate::has_error_type::HasErrorType;
 

--- a/crates/cgp-error/src/can_raise_error.rs
+++ b/crates/cgp-error/src/can_raise_error.rs
@@ -1,5 +1,5 @@
-use cgp_component_macro::cgp_component;
 use cgp_component::{DelegateComponent, HasComponents, UseDelegate};
+use cgp_component_macro::cgp_component;
 
 use crate::has_error_type::HasErrorType;
 

--- a/crates/cgp-error/src/has_error_type.rs
+++ b/crates/cgp-error/src/has_error_type.rs
@@ -1,7 +1,8 @@
 use core::fmt::Debug;
 
 use cgp_async::Async;
-use cgp_component::{cgp_component, DelegateComponent, HasComponents, WithProvider};
+use cgp_component_macro::cgp_component;
+use cgp_component::{DelegateComponent, HasComponents, WithProvider};
 use cgp_type::traits::has_type::ProvideType;
 
 /**

--- a/crates/cgp-error/src/has_error_type.rs
+++ b/crates/cgp-error/src/has_error_type.rs
@@ -1,8 +1,8 @@
 use core::fmt::Debug;
 
 use cgp_async::Async;
-use cgp_component_macro::cgp_component;
 use cgp_component::{DelegateComponent, HasComponents, WithProvider};
+use cgp_component_macro::cgp_component;
 use cgp_type::traits::has_type::ProvideType;
 
 /**

--- a/crates/cgp-extra/Cargo.toml
+++ b/crates/cgp-extra/Cargo.toml
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-run        = { version = "0.2.0" }
+cgp-run = { version = "0.2.0" }

--- a/crates/cgp-field-macro-lib/Cargo.toml
+++ b/crates/cgp-field-macro-lib/Cargo.toml
@@ -12,8 +12,8 @@ description  = """
 """
 
 [dependencies]
-syn = { version = "2.0.90", features = [ "full" ] }
-quote = "1.0.33"
-proc-macro2 = "1.0.92"
-itertools = "0.13.0"
-prettyplease = "0.2.20"
+syn             = { version = "2.0.90", features = [ "full" ] }
+quote           = "1.0.33"
+proc-macro2     = "1.0.92"
+itertools       = "0.13.0"
+prettyplease    = "0.2.20"

--- a/crates/cgp-field-macro/Cargo.toml
+++ b/crates/cgp-field-macro/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 
 [dependencies]
 cgp-field-macro-lib = { version = "0.2.0" }
-proc-macro2     = "1.0.92"
+proc-macro2         = "1.0.92"

--- a/crates/cgp-field/Cargo.toml
+++ b/crates/cgp-field/Cargo.toml
@@ -12,6 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-field-macro = { version = "0.2.0" }
 cgp-component   = { version = "0.2.0" }
 cgp-type        = { version = "0.2.0" }

--- a/crates/cgp-field/src/lib.rs
+++ b/crates/cgp-field/src/lib.rs
@@ -4,6 +4,5 @@ pub mod impls;
 pub mod traits;
 pub mod types;
 
-pub use cgp_field_macro::{product, symbol, HasField, Product, Sum};
 pub use traits::{FieldGetter, HasField, HasFieldMut, MutFieldGetter};
 pub use types::{Char, Cons, Either, Field, Index, Nil, Void};

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-component = { version = "0.2.0" }
+cgp-component       = { version = "0.2.0" }
 cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -13,3 +13,4 @@ description  = """
 
 [dependencies]
 cgp-component = { version = "0.2.0" }
+cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-inner/src/lib.rs
+++ b/crates/cgp-inner/src/lib.rs
@@ -2,8 +2,8 @@
 
 extern crate alloc;
 
-use cgp_component_macro::cgp_component;
 use cgp_component::{DelegateComponent, HasComponents};
+use cgp_component_macro::cgp_component;
 
 #[cgp_component {
     name: InnerComponent,

--- a/crates/cgp-inner/src/lib.rs
+++ b/crates/cgp-inner/src/lib.rs
@@ -2,7 +2,8 @@
 
 extern crate alloc;
 
-use cgp_component::{cgp_component, DelegateComponent, HasComponents};
+use cgp_component_macro::cgp_component;
+use cgp_component::{DelegateComponent, HasComponents};
 
 #[cgp_component {
     name: InnerComponent,

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -12,6 +12,7 @@ description  = """
 """
 
 [dependencies]
-cgp-async = { version = "0.2.0", default-features = false }
-cgp-error = { version = "0.2.0" }
-cgp-component = { version = "0.2.0" }
+cgp-async           = { version = "0.2.0", default-features = false }
+cgp-error           = { version = "0.2.0" }
+cgp-component       = { version = "0.2.0" }
+cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-run/src/lib.rs
+++ b/crates/cgp-run/src/lib.rs
@@ -7,6 +7,7 @@ use alloc::boxed::Box;
 
 use cgp_async::*;
 use cgp_component::*;
+use cgp_component_macro::*;
 use cgp_error::HasErrorType;
 
 #[cgp_component {

--- a/crates/cgp-type/Cargo.toml
+++ b/crates/cgp-type/Cargo.toml
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-component = { version = "0.2.0" }
+cgp-component       = { version = "0.2.0" }
 cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-type/Cargo.toml
+++ b/crates/cgp-type/Cargo.toml
@@ -13,3 +13,4 @@ description  = """
 
 [dependencies]
 cgp-component = { version = "0.2.0" }
+cgp-component-macro = { version = "0.2.0" }

--- a/crates/cgp-type/src/traits/has_type.rs
+++ b/crates/cgp-type/src/traits/has_type.rs
@@ -1,4 +1,5 @@
-use cgp_component::{cgp_component, DelegateComponent, HasComponents, UseContext, UseDelegate};
+use cgp_component_macro::cgp_component;
+use cgp_component::{DelegateComponent, HasComponents, UseContext, UseDelegate};
 
 #[cgp_component {
     name: TypeComponent,

--- a/crates/cgp-type/src/traits/has_type.rs
+++ b/crates/cgp-type/src/traits/has_type.rs
@@ -1,5 +1,5 @@
-use cgp_component_macro::cgp_component;
 use cgp_component::{DelegateComponent, HasComponents, UseContext, UseDelegate};
+use cgp_component_macro::cgp_component;
 
 #[cgp_component {
     name: TypeComponent,


### PR DESCRIPTION
This PR removes the inclusion of the proc macro crates as the dependency of library crates. The main purpose for this is so that the proc macro crates can evolve more easily with semver-breaking changes, but keep the library crates stable without breaking changes.

- Remove `cgp-component-macro` crate from being a dependency of `cgp-component`.
- Remove `cgp-field-macro` crate from being a dependency of `cgp-field`.