### PR TITLE
Error crates refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.3.0 (pre-release)
 
+- Error crates refactoring - [#48](https://github.com/contextgeneric/cgp/pull/48)
+    - Remove `Async` trait bound from `HasErrorType::Error`.
+    - Introduce `HasAsyncErrorType` trait used for adding `Async` constraint to `HasErrorType::Error`.
+    - Introduce `CanWrapError` trait.
+    - Introduce generic `ErrorRaiser` providers in `cgp-error`.
+    - Rename and reoganize constructs in `cgp-error-eyre` and `cgp-error-std`.
+    - Introduce `cgp-error-anyhow` crate.
+
 - Decouple component and field macro crates from the library crates - [#47](https://github.com/contextgeneric/cgp/pull/47)
     - Remove `cgp-component-macro` crate from being a dependency of `cgp-component`.
     - Remove `cgp-field-macro` crate from being a dependency of `cgp-field`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "cgp"
 version = "0.2.0"
 dependencies = [
@@ -72,6 +78,14 @@ dependencies = [
  "cgp-component",
  "cgp-component-macro",
  "cgp-type",
+]
+
+[[package]]
+name = "cgp-error-anyhow"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "cgp-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/cgp-field-macro",
     "crates/cgp-field-macro-lib",
     "crates/cgp-error",
+    "crates/cgp-error-anyhow",
     "crates/cgp-error-eyre",
     "crates/cgp-error-std",
     "crates/cgp-run",

--- a/crates/cgp-async-macro/src/lib.rs
+++ b/crates/cgp-async-macro/src/lib.rs
@@ -1,7 +1,10 @@
+#![no_std]
+
 /*!
    This library provides helper macros for using async functions in traits.
 */
 
+extern crate alloc;
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/crates/cgp-async-macro/src/strip_async.rs
+++ b/crates/cgp-async-macro/src/strip_async.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use proc_macro2::{Group, TokenStream, TokenTree};
 use syn::parse::{Parse, ParseStream};
 use syn::token::{Async, Await, Dot, Fn};

--- a/crates/cgp-async/src/lib.rs
+++ b/crates/cgp-async/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub mod traits;
 
 pub use traits::{Async, MaybeSend, MaybeStatic, MaybeSync};

--- a/crates/cgp-async/src/traits/async.rs
+++ b/crates/cgp-async/src/traits/async.rs
@@ -4,27 +4,7 @@ use crate::traits::sync::MaybeSync;
 
 /**
    This is defined as a convenient constraint alias to
-   `Sized + Send + Sync + 'static`.
-
-   This constraint is commonly required to be present in almost all associated
-   types. The `Sized` constraint is commonly required for associated types to be
-   used as generic parameters. The `Send + Sync + 'static` constraints are
-   important for the use of async functions inside traits.
-
-   Because Rust do not currently natively support the use of async functions
-   in traits, we use the [`async_trait`] crate to desugar async functions
-   inside traits into functions returning
-   `Pin<Box<dyn Future + Send>>`. Due to the additional `Send` and lifetime
-   trait bounds inside the returned boxed future, almost all values that are
-   used inside the async functions are required to have types that implement
-   `Send` and `Sync`.
-
-   It is also common to require the associated types to have the `'static`
-   lifetime for them to be used inside async functions, because Rust would
-   otherwise infer a more restrictive lifetime that does not outlive the
-   async functions. The `'static` lifetime constraint here really means
-   that the types implementing `Async` must not contain any lifetime
-   parameter.
+   `Send + Sync + 'static`.
 */
 pub trait Async: MaybeSend + MaybeSync + MaybeStatic {}
 

--- a/crates/cgp-component-macro-lib/src/delegate_components/impl_delegate.rs
+++ b/crates/cgp-component-macro-lib/src/delegate_components/impl_delegate.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 use syn::{parse_quote, Generics, ImplItem, ImplItemType, ItemImpl, Path, Type};
 
 use crate::delegate_components::ast::{ComponentAst, DelegateEntriesAst};

--- a/crates/cgp-component-macro-lib/src/derive_component/component_spec.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/component_spec.rs
@@ -1,3 +1,4 @@
+use alloc::format;
 use proc_macro2::Span;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};

--- a/crates/cgp-component-macro-lib/src/derive_component/consumer_impl.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/consumer_impl.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Comma, For, Impl, Plus};
 use syn::{

--- a/crates/cgp-component-macro-lib/src/derive_component/delegate_fn.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/delegate_fn.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse_quote, ImplItemFn, Signature, TypePath, Visibility};

--- a/crates/cgp-component-macro-lib/src/derive_component/entry.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/entry.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;

--- a/crates/cgp-component-macro-lib/src/derive_component/provider_impl.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/provider_impl.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use proc_macro2::Span;
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Comma, For, Impl, Plus};

--- a/crates/cgp-component-macro-lib/src/derive_component/provider_trait.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/provider_trait.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use syn::punctuated::Punctuated;
 use syn::{parse_quote, Ident, ItemTrait, TraitItem};
 

--- a/crates/cgp-component-macro-lib/src/derive_component/replace_self_type.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/replace_self_type.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use itertools::Itertools;
 use proc_macro2::{Group, Ident, TokenStream, TokenTree};
 use quote::{format_ident, ToTokens};

--- a/crates/cgp-component-macro-lib/src/derive_component/snake_case.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/snake_case.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use proc_macro2::Span;
 use syn::Ident;
 

--- a/crates/cgp-component-macro-lib/src/for_each_replace.rs
+++ b/crates/cgp-component-macro-lib/src/for_each_replace.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use proc_macro2::{Group, TokenStream, TokenTree};
 use quote::{quote, ToTokens};
 use syn::__private::parse_brackets;

--- a/crates/cgp-component-macro-lib/src/lib.rs
+++ b/crates/cgp-component-macro-lib/src/lib.rs
@@ -1,9 +1,13 @@
+#![no_std]
+
 /*!
    This is an internal crate used by the `cgp-component-macro` crate. We implement the
    proc macros for `cgp-component` as a library, so that it can be more easily tested.
    The constructs are then re-exported as proc macros in the `cgp-component-macro` crate,
    which is defined as a proc macro crate.
 */
+
+extern crate alloc;
 
 pub mod delegate_components;
 pub mod derive_component;

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::string::ToString;
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{parse_quote, Ident, ItemTrait};

--- a/crates/cgp-component-macro-lib/src/preset/impl_is_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/impl_is_preset.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use syn::{parse_quote, Generics, Ident, ItemImpl, Type};
 
 use crate::delegate_components::ast::{ComponentAst, DelegateEntriesAst};

--- a/crates/cgp-component-macro-lib/src/tests/delegate_components.rs
+++ b/crates/cgp-component-macro-lib/src/tests/delegate_components.rs
@@ -2,7 +2,6 @@ use quote::quote;
 
 use crate::delegate_components;
 use crate::tests::helper::equal::equal_token_stream;
-use crate::tests::helper::format::format_token_stream;
 
 #[test]
 fn test_basic_delegate_components() {
@@ -49,8 +48,6 @@ fn test_delegate_components_containing_generics() {
         }
     })
     .unwrap();
-
-    println!("derived: {}", format_token_stream(&derived));
 
     let expected = quote! {
         impl<'a, FooParamA, FooParamB: FooConstraint> DelegateComponent<BarComponentA>

--- a/crates/cgp-component-macro-lib/src/tests/helper/format.rs
+++ b/crates/cgp-component-macro-lib/src/tests/helper/format.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use prettyplease::unparse;
 use proc_macro2::TokenStream;
 use syn::parse_file;

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /*!
    This crate provides the proc macros used for defining CGP components.
 */

--- a/crates/cgp-component/src/lib.rs
+++ b/crates/cgp-component/src/lib.rs
@@ -2,7 +2,6 @@
 
 /*!
    This crate defines the core CGP traits, [`DelegateComponent`] and [`HasComponents`].
-   It also re-export component macros provided by [`cgp_component_macro`].
 */
 
 pub mod traits;

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -3,6 +3,6 @@ pub use cgp_component::{DelegateComponent, HasComponents};
 pub use cgp_component_macro::{
     cgp_component, cgp_preset, delegate_components, for_each_replace, replace_with,
 };
-pub use cgp_error::{CanRaiseError, HasErrorType};
+pub use cgp_error::{CanRaiseError, CanWrapError, HasErrorType};
 pub use cgp_field::{Char, Cons, Either, HasField, HasFieldMut, Nil, Void};
 pub use cgp_field_macro::{product, symbol, HasField, Product, Sum};

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -3,6 +3,6 @@ pub use cgp_component::{DelegateComponent, HasComponents};
 pub use cgp_component_macro::{
     cgp_component, cgp_preset, delegate_components, for_each_replace, replace_with,
 };
-pub use cgp_error::{CanRaiseError, CanWrapError, HasErrorType};
+pub use cgp_error::traits::{CanRaiseError, CanWrapError, HasErrorType};
 pub use cgp_field::{Char, Cons, Either, HasField, HasFieldMut, Nil, Void};
 pub use cgp_field_macro::{product, symbol, HasField, Product, Sum};

--- a/crates/cgp-error-anyhow/Cargo.toml
+++ b/crates/cgp-error-anyhow/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name         = "cgp-error-anyhow"
+version      = "0.2.0"
+edition      = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+authors      = { workspace = true }
+rust-version = { workspace = true }
+keywords     = { workspace = true }
+description  = """
+    Context-generic programming error handlers implemented using eyre
+"""
+
+[dependencies]
+cgp-core    = { version = "0.2.0", default-features = false }
+anyhow      = { version = "1.0.95" }

--- a/crates/cgp-error-anyhow/Cargo.toml
+++ b/crates/cgp-error-anyhow/Cargo.toml
@@ -13,4 +13,4 @@ description  = """
 
 [dependencies]
 cgp-core    = { version = "0.2.0", default-features = false }
-anyhow      = { version = "1.0.95" }
+anyhow      = { version = "1.0.95", default-features = false }

--- a/crates/cgp-error-anyhow/src/impls/debug_error.rs
+++ b/crates/cgp-error-anyhow/src/impls/debug_error.rs
@@ -1,0 +1,17 @@
+use core::fmt::Debug;
+
+use anyhow::{anyhow, Error};
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+
+pub struct DebugAnyhowError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DebugAnyhowError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Error {
+        anyhow!("{:?}", e)
+    }
+}

--- a/crates/cgp-error-anyhow/src/impls/display_error.rs
+++ b/crates/cgp-error-anyhow/src/impls/display_error.rs
@@ -1,0 +1,17 @@
+use core::fmt::Display;
+
+use anyhow::{anyhow, Error};
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+
+pub struct DisplayAnyhowError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DisplayAnyhowError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Display,
+{
+    fn raise_error(e: E) -> Error {
+        anyhow!("{e}")
+    }
+}

--- a/crates/cgp-error-anyhow/src/impls/mod.rs
+++ b/crates/cgp-error-anyhow/src/impls/mod.rs
@@ -1,0 +1,9 @@
+pub mod debug_error;
+pub mod display_error;
+pub mod raise_anyhow_error;
+pub mod use_anyhow_error;
+
+pub use debug_error::*;
+pub use display_error::*;
+pub use raise_anyhow_error::*;
+pub use use_anyhow_error::*;

--- a/crates/cgp-error-anyhow/src/impls/raise_anyhow_error.rs
+++ b/crates/cgp-error-anyhow/src/impls/raise_anyhow_error.rs
@@ -1,0 +1,17 @@
+use core::error::Error as StdError;
+
+use anyhow::Error;
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+
+pub struct RaiseAnyhowError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseAnyhowError
+where
+    Context: HasErrorType<Error = Error>,
+    E: StdError + Send + Sync + 'static,
+{
+    fn raise_error(e: E) -> Error {
+        e.into()
+    }
+}

--- a/crates/cgp-error-anyhow/src/impls/use_anyhow_error.rs
+++ b/crates/cgp-error-anyhow/src/impls/use_anyhow_error.rs
@@ -1,0 +1,8 @@
+use anyhow::Error;
+use cgp_core::error::ProvideErrorType;
+
+pub struct UseAnyhowError;
+
+impl<Context> ProvideErrorType<Context> for UseAnyhowError {
+    type Error = Error;
+}

--- a/crates/cgp-error-anyhow/src/lib.rs
+++ b/crates/cgp-error-anyhow/src/lib.rs
@@ -1,0 +1,50 @@
+#![no_std]
+
+use core::error::Error as StdError;
+use core::fmt::{Debug, Display};
+
+use anyhow::{anyhow, Error};
+use cgp_core::error::{ErrorRaiser, ProvideErrorType};
+use cgp_core::prelude::*;
+
+pub struct UseAnyhowError;
+
+impl<Context> ProvideErrorType<Context> for UseAnyhowError {
+    type Error = Error;
+}
+
+pub struct RaiseStdError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseStdError
+where
+    Context: HasErrorType<Error = Error>,
+    E: StdError + Send + Sync + 'static,
+{
+    fn raise_error(e: E) -> Error {
+        e.into()
+    }
+}
+
+pub struct DebugError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DebugError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Error {
+        anyhow!("{:?}", e)
+    }
+}
+
+pub struct DisplayError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DisplayError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Display,
+{
+    fn raise_error(e: E) -> Error {
+        anyhow!("{e}")
+    }
+}

--- a/crates/cgp-error-anyhow/src/lib.rs
+++ b/crates/cgp-error-anyhow/src/lib.rs
@@ -1,50 +1,5 @@
 #![no_std]
 
-use core::error::Error as StdError;
-use core::fmt::{Debug, Display};
+pub mod impls;
 
-use anyhow::{anyhow, Error};
-use cgp_core::error::{ErrorRaiser, ProvideErrorType};
-use cgp_core::prelude::*;
-
-pub struct UseAnyhowError;
-
-impl<Context> ProvideErrorType<Context> for UseAnyhowError {
-    type Error = Error;
-}
-
-pub struct RaiseStdError;
-
-impl<Context, E> ErrorRaiser<Context, E> for RaiseStdError
-where
-    Context: HasErrorType<Error = Error>,
-    E: StdError + Send + Sync + 'static,
-{
-    fn raise_error(e: E) -> Error {
-        e.into()
-    }
-}
-
-pub struct DebugError;
-
-impl<Context, E> ErrorRaiser<Context, E> for DebugError
-where
-    Context: HasErrorType<Error = Error>,
-    E: Debug,
-{
-    fn raise_error(e: E) -> Error {
-        anyhow!("{:?}", e)
-    }
-}
-
-pub struct DisplayError;
-
-impl<Context, E> ErrorRaiser<Context, E> for DisplayError
-where
-    Context: HasErrorType<Error = Error>,
-    E: Display,
-{
-    fn raise_error(e: E) -> Error {
-        anyhow!("{e}")
-    }
-}
+pub use impls::*;

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -13,4 +13,4 @@ description  = """
 
 [dependencies]
 cgp-core    = { version = "0.2.0", default-features = false }
-eyre        = { version = "0.6.11" }
+eyre        = { version = "0.6.12", default-features = false }

--- a/crates/cgp-error-eyre/src/impls/debug_error.rs
+++ b/crates/cgp-error-eyre/src/impls/debug_error.rs
@@ -1,0 +1,17 @@
+use core::fmt::Debug;
+
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+use eyre::{eyre, Error};
+
+pub struct DebugEyreError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DebugEyreError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Error {
+        eyre!("{:?}", e)
+    }
+}

--- a/crates/cgp-error-eyre/src/impls/display_error.rs
+++ b/crates/cgp-error-eyre/src/impls/display_error.rs
@@ -1,0 +1,17 @@
+use core::fmt::Display;
+
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+use eyre::{eyre, Error};
+
+pub struct DisplayEyreError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DisplayEyreError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Display,
+{
+    fn raise_error(e: E) -> Error {
+        eyre!("{e}")
+    }
+}

--- a/crates/cgp-error-eyre/src/impls/mod.rs
+++ b/crates/cgp-error-eyre/src/impls/mod.rs
@@ -1,0 +1,9 @@
+pub mod debug_error;
+pub mod display_error;
+pub mod raise_eyre_error;
+pub mod use_eyre_error;
+
+pub use debug_error::*;
+pub use display_error::*;
+pub use raise_eyre_error::*;
+pub use use_eyre_error::*;

--- a/crates/cgp-error-eyre/src/impls/raise_eyre_error.rs
+++ b/crates/cgp-error-eyre/src/impls/raise_eyre_error.rs
@@ -1,0 +1,17 @@
+use core::error::Error as StdError;
+
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+use eyre::Error;
+
+pub struct RaiseEyreError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseEyreError
+where
+    Context: HasErrorType<Error = Error>,
+    E: StdError + Send + Sync + 'static,
+{
+    fn raise_error(e: E) -> Error {
+        e.into()
+    }
+}

--- a/crates/cgp-error-eyre/src/impls/use_eyre_error.rs
+++ b/crates/cgp-error-eyre/src/impls/use_eyre_error.rs
@@ -1,0 +1,8 @@
+use cgp_core::error::ProvideErrorType;
+use eyre::Error;
+
+pub struct UseEyreError;
+
+impl<Context> ProvideErrorType<Context> for UseEyreError {
+    type Error = Error;
+}

--- a/crates/cgp-error-eyre/src/lib.rs
+++ b/crates/cgp-error-eyre/src/lib.rs
@@ -1,50 +1,5 @@
 #![no_std]
 
-use core::error::Error as StdError;
-use core::fmt::{Debug, Display};
+pub mod impls;
 
-use cgp_core::error::{ErrorRaiser, ProvideErrorType};
-use cgp_core::prelude::*;
-use eyre::{eyre, Report};
-
-pub struct ProvideEyreError;
-
-impl<Context> ProvideErrorType<Context> for ProvideEyreError {
-    type Error = Report;
-}
-
-pub struct RaiseStdError;
-
-impl<Context, E> ErrorRaiser<Context, E> for RaiseStdError
-where
-    Context: HasErrorType<Error = Report>,
-    E: StdError + Send + Sync + 'static,
-{
-    fn raise_error(e: E) -> Report {
-        e.into()
-    }
-}
-
-pub struct RaiseDebugError;
-
-impl<Context, E> ErrorRaiser<Context, E> for RaiseDebugError
-where
-    Context: HasErrorType<Error = Report>,
-    E: Debug,
-{
-    fn raise_error(e: E) -> Report {
-        eyre!("{:?}", e)
-    }
-}
-
-pub struct RaiseDisplayError;
-
-impl<Context, E> ErrorRaiser<Context, E> for RaiseDisplayError
-where
-    Context: HasErrorType<Error = Report>,
-    E: Display,
-{
-    fn raise_error(e: E) -> Report {
-        eyre!("{e}")
-    }
-}
+pub use impls::*;

--- a/crates/cgp-error-eyre/src/lib.rs
+++ b/crates/cgp-error-eyre/src/lib.rs
@@ -1,5 +1,7 @@
+#![no_std]
+
+use core::error::Error as StdError;
 use core::fmt::{Debug, Display};
-use std::error::Error as StdError;
 
 use cgp_core::error::{ErrorRaiser, ProvideErrorType};
 use cgp_core::prelude::*;

--- a/crates/cgp-error-std/src/impls/debug_error.rs
+++ b/crates/cgp-error-std/src/impls/debug_error.rs
@@ -1,0 +1,19 @@
+use core::fmt::Debug;
+
+use alloc::boxed::Box;
+use alloc::format;
+use cgp_core::error::{ErrorRaiser, HasErrorType};
+
+use crate::types::{Error, StringError};
+
+pub struct DebugBoxedStdError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DebugBoxedStdError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Error {
+        Box::new(StringError::from(format!("{e:?}")))
+    }
+}

--- a/crates/cgp-error-std/src/impls/display_error.rs
+++ b/crates/cgp-error-std/src/impls/display_error.rs
@@ -1,0 +1,19 @@
+use core::fmt::Display;
+
+use alloc::boxed::Box;
+use alloc::format;
+use cgp_core::error::{ErrorRaiser, HasErrorType};
+
+use crate::types::{Error, StringError};
+
+pub struct DisplayBoxedStdError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DisplayBoxedStdError
+where
+    Context: HasErrorType<Error = Error>,
+    E: Display,
+{
+    fn raise_error(e: E) -> Error {
+        Box::new(StringError::from(format!("{e}")))
+    }
+}

--- a/crates/cgp-error-std/src/impls/mod.rs
+++ b/crates/cgp-error-std/src/impls/mod.rs
@@ -1,0 +1,9 @@
+pub mod debug_error;
+pub mod display_error;
+pub mod raise_boxed;
+pub mod use_boxed;
+
+pub use debug_error::*;
+pub use display_error::*;
+pub use raise_boxed::*;
+pub use use_boxed::*;

--- a/crates/cgp-error-std/src/impls/raise_boxed.rs
+++ b/crates/cgp-error-std/src/impls/raise_boxed.rs
@@ -1,0 +1,18 @@
+use core::error::Error as StdError;
+
+use cgp_core::error::ErrorRaiser;
+use cgp_core::prelude::*;
+
+use crate::types::Error;
+
+pub struct RaiseBoxedStdError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseBoxedStdError
+where
+    Context: HasErrorType<Error = Error>,
+    E: StdError + Send + Sync + 'static,
+{
+    fn raise_error(e: E) -> Error {
+        e.into()
+    }
+}

--- a/crates/cgp-error-std/src/impls/use_boxed.rs
+++ b/crates/cgp-error-std/src/impls/use_boxed.rs
@@ -1,0 +1,9 @@
+use cgp_core::error::ProvideErrorType;
+
+use crate::types::Error;
+
+pub struct UseBoxedStdError;
+
+impl<Context> ProvideErrorType<Context> for UseBoxedStdError {
+    type Error = Error;
+}

--- a/crates/cgp-error-std/src/lib.rs
+++ b/crates/cgp-error-std/src/lib.rs
@@ -2,29 +2,8 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
-use core::error::Error as StdError;
+pub mod impls;
+pub mod types;
 
-use cgp_core::error::{ErrorRaiser, ProvideErrorType};
-use cgp_core::prelude::*;
-
-pub type Error = Box<dyn StdError + Send + Sync + 'static>;
-
-pub struct HandleErrorsWithStdError;
-
-impl<Context> ProvideErrorType<Context> for HandleErrorsWithStdError
-where
-    Context: Async,
-{
-    type Error = Error;
-}
-
-impl<Context, E> ErrorRaiser<Context, E> for HandleErrorsWithStdError
-where
-    Context: HasErrorType<Error = Error>,
-    E: StdError + Send + Sync + 'static,
-{
-    fn raise_error(e: E) -> Error {
-        e.into()
-    }
-}
+pub use impls::*;
+pub use types::*;

--- a/crates/cgp-error-std/src/types/error.rs
+++ b/crates/cgp-error-std/src/types/error.rs
@@ -1,0 +1,4 @@
+use alloc::boxed::Box;
+use core::error::Error as StdError;
+
+pub type Error = Box<dyn StdError + Send + Sync + 'static>;

--- a/crates/cgp-error-std/src/types/mod.rs
+++ b/crates/cgp-error-std/src/types/mod.rs
@@ -1,0 +1,5 @@
+pub mod error;
+pub mod string;
+
+pub use error::*;
+pub use string::*;

--- a/crates/cgp-error-std/src/types/string.rs
+++ b/crates/cgp-error-std/src/types/string.rs
@@ -1,0 +1,28 @@
+use core::error::Error;
+use core::fmt::{Debug, Display};
+
+use alloc::string::String;
+
+pub struct StringError {
+    pub message: String,
+}
+
+impl From<String> for StringError {
+    fn from(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl Debug for StringError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.message, f)
+    }
+}
+
+impl Display for StringError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.message, f)
+    }
+}
+
+impl Error for StringError {}

--- a/crates/cgp-error/src/impls/debug_error.rs
+++ b/crates/cgp-error/src/impls/debug_error.rs
@@ -1,0 +1,15 @@
+use core::fmt::Debug;
+
+use crate::{CanRaiseError, ErrorRaiser};
+
+pub struct DebugError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DebugError
+where
+    Context: CanRaiseError<String>,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Context::Error {
+        Context::raise_error(format!("{e:?}"))
+    }
+}

--- a/crates/cgp-error/src/impls/debug_error.rs
+++ b/crates/cgp-error/src/impls/debug_error.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::string::String;
 use core::fmt::Debug;
 
 use crate::{CanRaiseError, ErrorRaiser};

--- a/crates/cgp-error/src/impls/debug_error.rs
+++ b/crates/cgp-error/src/impls/debug_error.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::string::String;
 use core::fmt::Debug;
 
-use crate::{CanRaiseError, ErrorRaiser};
+use crate::traits::{CanRaiseError, ErrorRaiser};
 
 pub struct DebugError;
 

--- a/crates/cgp-error/src/impls/discard_detail.rs
+++ b/crates/cgp-error/src/impls/discard_detail.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorWrapper, HasErrorType};
+use crate::traits::{ErrorWrapper, HasErrorType};
 
 pub struct DiscardDetail;
 

--- a/crates/cgp-error/src/impls/discard_detail.rs
+++ b/crates/cgp-error/src/impls/discard_detail.rs
@@ -1,0 +1,12 @@
+use crate::{ErrorWrapper, HasErrorType};
+
+pub struct DiscardDetail;
+
+impl<Context, Detail> ErrorWrapper<Context, Detail> for DiscardDetail
+where
+    Context: HasErrorType,
+{
+    fn wrap_error(error: Context::Error, _detail: Detail) -> Context::Error {
+        error
+    }
+}

--- a/crates/cgp-error/src/impls/display_error.rs
+++ b/crates/cgp-error/src/impls/display_error.rs
@@ -1,0 +1,15 @@
+use core::fmt::Display;
+
+use crate::{CanRaiseError, ErrorRaiser};
+
+pub struct DisplayError;
+
+impl<Context, E> ErrorRaiser<Context, E> for DisplayError
+where
+    Context: CanRaiseError<String>,
+    E: Display,
+{
+    fn raise_error(e: E) -> Context::Error {
+        Context::raise_error(format!("{e}"))
+    }
+}

--- a/crates/cgp-error/src/impls/display_error.rs
+++ b/crates/cgp-error/src/impls/display_error.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::string::String;
 use core::fmt::Display;
 
-use crate::{CanRaiseError, ErrorRaiser};
+use crate::traits::{CanRaiseError, ErrorRaiser};
 
 pub struct DisplayError;
 

--- a/crates/cgp-error/src/impls/display_error.rs
+++ b/crates/cgp-error/src/impls/display_error.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::string::String;
 use core::fmt::Display;
 
 use crate::{CanRaiseError, ErrorRaiser};

--- a/crates/cgp-error/src/impls/infallible.rs
+++ b/crates/cgp-error/src/impls/infallible.rs
@@ -1,0 +1,14 @@
+use core::convert::Infallible;
+
+use crate::{ErrorRaiser, HasErrorType};
+
+pub struct RaiseInfallible;
+
+impl<Context> ErrorRaiser<Context, Infallible> for RaiseInfallible
+where
+    Context: HasErrorType,
+{
+    fn raise_error(e: Infallible) -> Context::Error {
+        match e {}
+    }
+}

--- a/crates/cgp-error/src/impls/infallible.rs
+++ b/crates/cgp-error/src/impls/infallible.rs
@@ -1,6 +1,6 @@
 use core::convert::Infallible;
 
-use crate::{ErrorRaiser, HasErrorType};
+use crate::traits::{ErrorRaiser, HasErrorType};
 
 pub struct RaiseInfallible;
 

--- a/crates/cgp-error/src/impls/mod.rs
+++ b/crates/cgp-error/src/impls/mod.rs
@@ -1,11 +1,13 @@
 pub mod debug_error;
 pub mod display_error;
 pub mod infallible;
+pub mod panic_error;
 pub mod raise_from;
 pub mod return_error;
 
 pub use debug_error::*;
 pub use display_error::*;
 pub use infallible::*;
+pub use panic_error::*;
 pub use raise_from::*;
 pub use return_error::*;

--- a/crates/cgp-error/src/impls/mod.rs
+++ b/crates/cgp-error/src/impls/mod.rs
@@ -1,0 +1,3 @@
+pub mod raise_from;
+
+pub use raise_from::*;

--- a/crates/cgp-error/src/impls/mod.rs
+++ b/crates/cgp-error/src/impls/mod.rs
@@ -1,7 +1,11 @@
 pub mod debug_error;
 pub mod display_error;
+pub mod infallible;
 pub mod raise_from;
+pub mod return_error;
 
 pub use debug_error::*;
 pub use display_error::*;
+pub use infallible::*;
 pub use raise_from::*;
+pub use return_error::*;

--- a/crates/cgp-error/src/impls/mod.rs
+++ b/crates/cgp-error/src/impls/mod.rs
@@ -1,3 +1,7 @@
+pub mod debug_error;
+pub mod display_error;
 pub mod raise_from;
 
+pub use debug_error::*;
+pub use display_error::*;
 pub use raise_from::*;

--- a/crates/cgp-error/src/impls/mod.rs
+++ b/crates/cgp-error/src/impls/mod.rs
@@ -1,4 +1,5 @@
 pub mod debug_error;
+pub mod discard_detail;
 pub mod display_error;
 pub mod infallible;
 pub mod panic_error;
@@ -6,6 +7,7 @@ pub mod raise_from;
 pub mod return_error;
 
 pub use debug_error::*;
+pub use discard_detail::*;
 pub use display_error::*;
 pub use infallible::*;
 pub use panic_error::*;

--- a/crates/cgp-error/src/impls/panic_error.rs
+++ b/crates/cgp-error/src/impls/panic_error.rs
@@ -1,0 +1,15 @@
+use core::fmt::Debug;
+
+use crate::{ErrorRaiser, HasErrorType};
+
+pub struct PanicOnError;
+
+impl<Context, E> ErrorRaiser<Context, E> for PanicOnError
+where
+    Context: HasErrorType,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Context::Error {
+        panic!("{e:?}")
+    }
+}

--- a/crates/cgp-error/src/impls/panic_error.rs
+++ b/crates/cgp-error/src/impls/panic_error.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use crate::{ErrorRaiser, HasErrorType};
+use crate::traits::{ErrorRaiser, HasErrorType};
 
 pub struct PanicOnError;
 

--- a/crates/cgp-error/src/impls/raise_from.rs
+++ b/crates/cgp-error/src/impls/raise_from.rs
@@ -1,0 +1,13 @@
+use crate::{ErrorRaiser, HasErrorType};
+
+pub struct RaiseFrom;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseFrom
+where
+    Context: HasErrorType,
+    Context::Error: From<E>,
+{
+    fn raise_error(e: E) -> Context::Error {
+        e.into()
+    }
+}

--- a/crates/cgp-error/src/impls/raise_from.rs
+++ b/crates/cgp-error/src/impls/raise_from.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorRaiser, HasErrorType};
+use crate::traits::{ErrorRaiser, HasErrorType};
 
 pub struct RaiseFrom;
 

--- a/crates/cgp-error/src/impls/return_error.rs
+++ b/crates/cgp-error/src/impls/return_error.rs
@@ -1,0 +1,12 @@
+use crate::{ErrorRaiser, HasErrorType};
+
+pub struct ReturnError;
+
+impl<Context, E> ErrorRaiser<Context, E> for ReturnError
+where
+    Context: HasErrorType<Error = E>,
+{
+    fn raise_error(e: E) -> E {
+        e
+    }
+}

--- a/crates/cgp-error/src/impls/return_error.rs
+++ b/crates/cgp-error/src/impls/return_error.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorRaiser, HasErrorType};
+use crate::traits::{ErrorRaiser, HasErrorType};
 
 pub struct ReturnError;
 

--- a/crates/cgp-error/src/lib.rs
+++ b/crates/cgp-error/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod impls;
 pub mod traits;
 

--- a/crates/cgp-error/src/lib.rs
+++ b/crates/cgp-error/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod impls;
 pub mod traits;
 
 pub use traits::*;

--- a/crates/cgp-error/src/lib.rs
+++ b/crates/cgp-error/src/lib.rs
@@ -1,5 +1,3 @@
-mod can_raise_error;
-mod has_error_type;
+pub mod traits;
 
-pub use can_raise_error::*;
-pub use has_error_type::*;
+pub use traits::*;

--- a/crates/cgp-error/src/traits/can_raise_error.rs
+++ b/crates/cgp-error/src/traits/can_raise_error.rs
@@ -1,7 +1,7 @@
 use cgp_component::{DelegateComponent, HasComponents, UseDelegate};
 use cgp_component_macro::cgp_component;
 
-use crate::has_error_type::HasErrorType;
+use crate::traits::has_error_type::HasErrorType;
 
 /**
    Used for injecting external error types into [`Self::Error`](HasErrorType::Error).

--- a/crates/cgp-error/src/traits/can_wrap_error.rs
+++ b/crates/cgp-error/src/traits/can_wrap_error.rs
@@ -1,0 +1,22 @@
+use cgp_component::{DelegateComponent, HasComponents, UseDelegate};
+use cgp_component_macro::cgp_component;
+
+use crate::HasErrorType;
+
+#[cgp_component {
+    provider: ErrorWrapper,
+}]
+pub trait CanWrapError<Detail>: HasErrorType {
+    fn wrap_error(error: Self::Error, detail: Detail) -> Self::Error;
+}
+
+impl<Context, Detail, Components> ErrorWrapper<Context, Detail> for UseDelegate<Components>
+where
+    Context: HasErrorType,
+    Components: DelegateComponent<Detail>,
+    Components::Delegate: ErrorWrapper<Context, Detail>,
+{
+    fn wrap_error(error: Context::Error, detail: Detail) -> Context::Error {
+        Components::Delegate::wrap_error(error, detail)
+    }
+}

--- a/crates/cgp-error/src/traits/can_wrap_error.rs
+++ b/crates/cgp-error/src/traits/can_wrap_error.rs
@@ -1,7 +1,7 @@
 use cgp_component::{DelegateComponent, HasComponents, UseDelegate};
 use cgp_component_macro::cgp_component;
 
-use crate::HasErrorType;
+use crate::traits::HasErrorType;
 
 #[cgp_component {
     provider: ErrorWrapper,

--- a/crates/cgp-error/src/traits/has_async_error_type.rs
+++ b/crates/cgp-error/src/traits/has_async_error_type.rs
@@ -1,0 +1,7 @@
+use cgp_async::Async;
+
+use crate::HasErrorType;
+
+pub trait HasAsyncErrorType: HasErrorType<Error: Async> {}
+
+impl<Context> HasAsyncErrorType for Context where Context: HasErrorType<Error: Async> {}

--- a/crates/cgp-error/src/traits/has_async_error_type.rs
+++ b/crates/cgp-error/src/traits/has_async_error_type.rs
@@ -1,6 +1,6 @@
 use cgp_async::Async;
 
-use crate::HasErrorType;
+use crate::traits::HasErrorType;
 
 pub trait HasAsyncErrorType: HasErrorType<Error: Async> {}
 

--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -27,7 +27,7 @@ pub trait HasErrorType {
        This is to allow `Self::Error` to be used in calls like `.unwrap()`,
        as well as for simpler error logging.
     */
-    type Error: Async + Debug;
+    type Error: Debug;
 }
 
 pub type ErrorOf<Context> = <Context as HasErrorType>::Error;

--- a/crates/cgp-error/src/traits/mod.rs
+++ b/crates/cgp-error/src/traits/mod.rs
@@ -1,7 +1,9 @@
 pub mod can_raise_error;
+pub mod can_wrap_error;
 pub mod has_async_error_type;
 pub mod has_error_type;
 
 pub use can_raise_error::*;
+pub use can_wrap_error::*;
 pub use has_async_error_type::*;
 pub use has_error_type::*;

--- a/crates/cgp-error/src/traits/mod.rs
+++ b/crates/cgp-error/src/traits/mod.rs
@@ -1,0 +1,7 @@
+pub mod can_raise_error;
+pub mod has_async_error_type;
+pub mod has_error_type;
+
+pub use can_raise_error::*;
+pub use has_async_error_type::*;
+pub use has_error_type::*;

--- a/crates/cgp-extra/src/lib.rs
+++ b/crates/cgp-extra/src/lib.rs
@@ -1,1 +1,3 @@
+#![no_std]
+
 pub use cgp_run as run;

--- a/crates/cgp-field-macro-lib/src/field.rs
+++ b/crates/cgp-field-macro-lib/src/field.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{parse_quote, Fields, ItemImpl, ItemStruct};

--- a/crates/cgp-field-macro-lib/src/lib.rs
+++ b/crates/cgp-field-macro-lib/src/lib.rs
@@ -1,9 +1,13 @@
+#![no_std]
+
 /*!
    This is an internal crate used by the `cgp-field-macro` crate. We implement the
    proc macros for `cgp-field` as a library, so that it can be more easily tested.
    The constructs are then re-exported as proc macros in the `cgp-field-macro` crate,
    which is defined as a proc macro crate.
 */
+
+extern crate alloc;
 
 pub mod field;
 pub mod product;

--- a/crates/cgp-field-macro-lib/src/tests/helper/format.rs
+++ b/crates/cgp-field-macro-lib/src/tests/helper/format.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use prettyplease::unparse;
 use proc_macro2::TokenStream;
 use syn::parse_file;

--- a/crates/cgp-field-macro-lib/src/tests/product.rs
+++ b/crates/cgp-field-macro-lib/src/tests/product.rs
@@ -1,3 +1,4 @@
+use alloc::string::ToString;
 use quote::quote;
 
 use crate::product::{make_product_expr, make_product_type, make_sum_type};

--- a/crates/cgp-field-macro/src/lib.rs
+++ b/crates/cgp-field-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/crates/cgp-sync/src/lib.rs
+++ b/crates/cgp-sync/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub use cgp_async_macro::strip_async as async_trait;
 
 pub trait Async: Sized + 'static {}

--- a/crates/cgp/src/lib.rs
+++ b/crates/cgp/src/lib.rs
@@ -1,2 +1,4 @@
+#![no_std]
+
 pub use cgp_core::prelude;
 pub use {cgp_core as core, cgp_extra as extra};


### PR DESCRIPTION
- Remove `Async` trait bound from `HasErrorType::Error`.
- Introduce `HasAsyncErrorType` trait used for adding `Async` constraint to `HasErrorType::Error`.
- Introduce `CanWrapError` trait.
- Introduce generic `ErrorRaiser` providers in `cgp-error`.
- Rename and reoganize constructs in `cgp-error-eyre` and `cgp-error-std`.
- Introduce `cgp-error-anyhow` crate.