### PR TITLE
Move `cgp-inner` to `cgp-extra`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.3.0 (pre-release)
 
+- Move `cgp-inner` to `cgp-extra` - [#51](https://github.com/contextgeneric/cgp/pull/51)
+    - Remove re-export of `cgp-inner` from `cgp-core`.
+    - Re-export `cgp-inner` and `cgp-runtime` from `cgp-extra`.
+
+- Introduce `cgp-runtime` crate - [#50](https://github.com/contextgeneric/cgp/pull/50)
+    - Introduce the `HasRuntimeType` and `HasRuntime` traits.
+    - Introduce `HasAsyncRuntimeType` trait used for adding `Async` constraint to `HasRuntimeType::Error`.
+
 - Error crates refactoring - [#48](https://github.com/contextgeneric/cgp/pull/48)
     - Remove `Async` trait bound from `HasErrorType::Error`.
     - Introduce `HasAsyncErrorType` trait used for adding `Async` constraint to `HasErrorType::Error`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,6 @@ dependencies = [
  "cgp-error",
  "cgp-field",
  "cgp-field-macro",
- "cgp-inner",
  "cgp-type",
 ]
 
@@ -107,7 +106,9 @@ dependencies = [
 name = "cgp-extra"
 version = "0.2.0"
 dependencies = [
+ "cgp-inner",
  "cgp-run",
+ "cgp-runtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,5 @@ cgp-field-macro             = { path = "./crates/cgp-field-macro" }
 cgp-field-macro-lib         = { path = "./crates/cgp-field-macro-lib" }
 cgp-error                   = { path = "./crates/cgp-error" }
 cgp-run                     = { path = "./crates/cgp-run" }
+cgp-runtime                 = { path = "./crates/cgp-runtime" }
 cgp-inner                   = { path = "./crates/cgp-inner" }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -23,4 +23,3 @@ cgp-type            = { version = "0.2.0" }
 cgp-error           = { version = "0.2.0" }
 cgp-field           = { version = "0.2.0" }
 cgp-field-macro     = { version = "0.2.0" }
-cgp-inner           = { version = "0.2.0" }

--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -3,7 +3,4 @@
 pub mod prelude;
 
 pub use cgp_async::{async_trait, Async};
-pub use {
-    cgp_component as component, cgp_error as error, cgp_field as field, cgp_inner as inner,
-    cgp_type as types,
-};
+pub use {cgp_component as component, cgp_error as error, cgp_field as field, cgp_type as types};

--- a/crates/cgp-extra/Cargo.toml
+++ b/crates/cgp-extra/Cargo.toml
@@ -12,4 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-run = { version = "0.2.0" }
+cgp-run     = { version = "0.2.0" }
+cgp-inner   = { version = "0.2.0" }
+cgp-runtime = { version = "0.2.0" }

--- a/crates/cgp-extra/src/lib.rs
+++ b/crates/cgp-extra/src/lib.rs
@@ -1,3 +1,5 @@
 #![no_std]
 
+pub use cgp_inner as inner;
 pub use cgp_run as run;
+pub use cgp_runtime as runtime;


### PR DESCRIPTION
- Remove re-export of `cgp-inner` from `cgp-core`.
- Re-export `cgp-inner` and `cgp-runtime` from `cgp-extra`.