### PR TITLE
Revert back minimal Rust version to 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-resolver = "3"
+resolver = "2"
 
 members = [
     "crates/cgp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version    = "1.84"
+rust-version    = "1.81"
 edition         = "2021"
 license         = "Apache-2.0"
 repository      = "https://github.com/contextgeneric/cgp"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84"
+channel = "1.81"
 profile = "default"


### PR DESCRIPTION
Wasm builds for Rust v1.82 onward is still broken on Wasmer, so unfortunately we cannot proceed to use new features in Rust v1.82+.