### PR TITLE
Introduce `#[cgp_context]` attribute macro for CGP contexts

### DIFF
--- a/crates/cgp-component-macro-lib/src/derive_context/derive.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/derive.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_quote, Ident, ItemImpl, ItemStruct};
+use syn::{parse_quote, AngleBracketedGenericArguments, Ident, ItemImpl, ItemStruct};
 
 use crate::derive_context::ContextSpec;
 
@@ -15,13 +15,28 @@ pub fn derive_context(attr: TokenStream, body: TokenStream) -> syn::Result<Token
 
     let has_components_impl: ItemImpl = derive_has_components(provider_name, &context_struct);
 
-    Ok(quote! {
+    let base_derived = quote! {
         #context_struct
 
         #provider_struct
 
         #has_components_impl
-    })
+    };
+
+    if let Some((preset_name, preset_generics)) = &context_spec.preset {
+        let (delegate_impl, is_provider_impl) =
+            derive_delegate_preset(provider_name, preset_name, preset_generics);
+
+        Ok(quote! {
+            #base_derived
+
+            #delegate_impl
+
+            #is_provider_impl
+        })
+    } else {
+        Ok(base_derived)
+    }
 }
 
 pub fn derive_has_components(provider_name: &Ident, context_struct: &ItemStruct) -> ItemImpl {
@@ -36,4 +51,36 @@ pub fn derive_has_components(provider_name: &Ident, context_struct: &ItemStruct)
             type Components = #provider_name;
         }
     }
+}
+
+pub fn derive_delegate_preset(
+    provider_name: &Ident,
+    preset_name: &Ident,
+    preset_generics: &Option<AngleBracketedGenericArguments>,
+) -> (ItemImpl, ItemImpl) {
+    let preset_trait_name = Ident::new(&format!("Is{preset_name}"), preset_name.span());
+
+    let delegate_impl: ItemImpl = parse_quote! {
+        impl<__Name__>
+            DelegateComponent<__Name__>
+            for #provider_name
+        where
+            Self: #preset_trait_name < __Name__ >,
+        {
+            type Delegate = #preset_name #preset_generics ;
+        }
+    };
+
+    let is_provider_impl: ItemImpl = parse_quote! {
+        impl<__Name__, __Context__, __Params__>
+            IsProviderFor<__Name__, __Context__, __Params__>
+            for #provider_name
+        where
+            Self: #preset_trait_name < __Name__ >,
+            #preset_name #preset_generics: IsProviderFor<__Name__, __Context__, __Params__>,
+        {
+        }
+    };
+
+    (delegate_impl, is_provider_impl)
 }

--- a/crates/cgp-component-macro-lib/src/derive_context/derive.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/derive.rs
@@ -1,0 +1,39 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, Ident, ItemImpl, ItemStruct};
+
+use crate::derive_context::ContextSpec;
+
+pub fn derive_context(attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+    let context_spec: ContextSpec = syn::parse2(attr)?;
+
+    let context_struct: ItemStruct = syn::parse2(body)?;
+
+    let provider_name = &context_spec.provider_name;
+
+    let provider_struct: ItemStruct = parse_quote!( pub struct #provider_name; );
+
+    let has_components_impl: ItemImpl = derive_has_components(provider_name, &context_struct);
+
+    Ok(quote! {
+        #context_struct
+
+        #provider_struct
+
+        #has_components_impl
+    })
+}
+
+pub fn derive_has_components(provider_name: &Ident, context_struct: &ItemStruct) -> ItemImpl {
+    let context_name = &context_struct.ident;
+
+    let (impl_generics, ty_generics, where_clause) = context_struct.generics.split_for_impl();
+
+    parse_quote! {
+        impl #impl_generics HasComponents for #context_name #ty_generics
+            #where_clause
+        {
+            type Components = #provider_name;
+        }
+    }
+}

--- a/crates/cgp-component-macro-lib/src/derive_context/mod.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/mod.rs
@@ -1,0 +1,5 @@
+mod derive;
+mod spec;
+
+pub use derive::*;
+pub use spec::*;

--- a/crates/cgp-component-macro-lib/src/derive_context/spec.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/spec.rs
@@ -1,0 +1,14 @@
+use syn::parse::{Parse, ParseStream};
+use syn::Ident;
+
+pub struct ContextSpec {
+    pub provider_name: Ident,
+}
+
+impl Parse for ContextSpec {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let provider_name = input.parse()?;
+
+        Ok(Self { provider_name })
+    }
+}

--- a/crates/cgp-component-macro-lib/src/derive_context/spec.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/spec.rs
@@ -1,14 +1,35 @@
 use syn::parse::{Parse, ParseStream};
-use syn::Ident;
+use syn::token::{Colon, Lt};
+use syn::{AngleBracketedGenericArguments, Ident};
 
 pub struct ContextSpec {
     pub provider_name: Ident,
+    pub preset: Option<(Ident, Option<AngleBracketedGenericArguments>)>,
 }
 
 impl Parse for ContextSpec {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let provider_name = input.parse()?;
 
-        Ok(Self { provider_name })
+        let colon: Option<Colon> = input.parse()?;
+
+        let preset = match colon {
+            Some(_) => {
+                let preset_name: Ident = input.parse()?;
+                let preset_generics = if input.peek(Lt) {
+                    Some(input.parse()?)
+                } else {
+                    None
+                };
+
+                Some((preset_name, preset_generics))
+            }
+            None => None,
+        };
+
+        Ok(Self {
+            provider_name,
+            preset,
+        })
     }
 }

--- a/crates/cgp-component-macro-lib/src/lib.rs
+++ b/crates/cgp-component-macro-lib/src/lib.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 
 pub(crate) mod delegate_components;
 pub(crate) mod derive_component;
+pub(crate) mod derive_context;
 pub(crate) mod derive_provider;
 pub(crate) mod for_each_replace;
 pub(crate) mod getter_component;
@@ -24,6 +25,7 @@ pub use derive_provider::derive_provider;
 
 pub use crate::delegate_components::delegate_components;
 pub use crate::derive_component::derive_component;
+pub use crate::derive_context::derive_context;
 pub use crate::for_each_replace::{handle_for_each_replace, handle_replace};
 pub use crate::getter_component::derive::{derive_auto_getter_component, derive_getter_component};
 pub use crate::preset::define_preset;

--- a/crates/cgp-component-macro-lib/src/tests/derive_context.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_context.rs
@@ -1,0 +1,93 @@
+use quote::quote;
+
+use crate::derive_context;
+use crate::tests::helper::equal::assert_equal_token_stream;
+use crate::tests::helper::format::format_token_stream;
+
+#[test]
+fn test_basic_derive_context() {
+    let derived = derive_context(
+        quote! { FooComponents },
+        quote! {
+            pub struct FooContext<Bar: BarConstraint>
+            where
+                Bar: BazConstraint,
+            {
+                pub bar: PhantomData<Bar>,
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {
+        pub struct FooContext<Bar: BarConstraint>
+        where
+            Bar: BazConstraint,
+        {
+            pub bar: PhantomData<Bar>,
+        }
+
+        pub struct FooComponents;
+
+        impl<Bar: BarConstraint> HasComponents for FooContext<Bar>
+        where
+            Bar: BazConstraint,
+        {
+            type Components = FooComponents;
+        }
+    };
+
+    println!("derived: {}", format_token_stream(&derived));
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
+fn test_derive_context_with_preset() {
+    let derived = derive_context(
+        quote! { FooComponents: FooPreset<BaseComponents> },
+        quote! {
+            pub struct FooContext<Bar: BarConstraint>
+            where
+                Bar: BazConstraint,
+            {
+                pub bar: PhantomData<Bar>,
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {
+        pub struct FooContext<Bar: BarConstraint>
+        where
+            Bar: BazConstraint,
+        {
+            pub bar: PhantomData<Bar>,
+        }
+
+        pub struct FooComponents;
+
+        impl<Bar: BarConstraint> HasComponents for FooContext<Bar>
+        where
+            Bar: BazConstraint,
+        {
+            type Components = FooComponents;
+        }
+
+        impl<__Name__> DelegateComponent<__Name__> for FooComponents
+        where
+            Self: IsFooPreset<__Name__>,
+        {
+            type Delegate = FooPreset<BaseComponents>;
+        }
+
+        impl<__Name__, __Context__, __Params__> IsProviderFor<__Name__, __Context__, __Params__>
+        for FooComponents
+        where
+            Self: IsFooPreset<__Name__>,
+            FooPreset<BaseComponents>: IsProviderFor<__Name__, __Context__, __Params__>,
+        {}
+    };
+
+    assert_equal_token_stream(&derived, &expected);
+}

--- a/crates/cgp-component-macro-lib/src/tests/helper/equal.rs
+++ b/crates/cgp-component-macro-lib/src/tests/helper/equal.rs
@@ -5,3 +5,15 @@ use crate::tests::helper::format::format_token_stream;
 pub fn equal_token_stream(left: &TokenStream, right: &TokenStream) -> bool {
     format_token_stream(left) == format_token_stream(right)
 }
+
+pub fn assert_equal_token_stream(derived: &TokenStream, expected: &TokenStream) {
+    let formatted_derived = format_token_stream(derived);
+    let formatted_expected = format_token_stream(expected);
+
+    if formatted_derived != formatted_expected {
+        panic!(
+            "token stream does not match. expected:\n{}\ngot:\n{}",
+            formatted_expected, formatted_derived,
+        );
+    }
+}

--- a/crates/cgp-component-macro-lib/src/tests/mod.rs
+++ b/crates/cgp-component-macro-lib/src/tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod define_preset;
 pub mod delegate_components;
 pub mod derive_component;
+pub mod derive_context;
 pub mod derive_provider;
 pub mod for_each_replace;
 pub mod helper;

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -57,6 +57,13 @@ pub fn cgp_type(body: TokenStream) -> TokenStream {
         .into()
 }
 
+#[proc_macro_attribute]
+pub fn cgp_context(attr: TokenStream, item: TokenStream) -> TokenStream {
+    cgp_component_macro_lib::derive_context(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
 #[proc_macro]
 pub fn for_each_replace(body: TokenStream) -> TokenStream {
     cgp_component_macro_lib::handle_for_each_replace(body.into())

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -4,7 +4,7 @@ pub use cgp_component::{
     WithProvider,
 };
 pub use cgp_component_macro::{
-    cgp_auto_getter, cgp_component, cgp_getter, cgp_preset, cgp_provider, cgp_type,
+    cgp_auto_getter, cgp_component, cgp_context, cgp_getter, cgp_preset, cgp_provider, cgp_type,
     delegate_components, for_each_replace, replace_with,
 };
 pub use cgp_error::{


### PR DESCRIPTION
- Introduce `#[cgp_context]` macro, which automatically derives the component struct and `HasComponents` impl.
- If a supertrait syntax is used, blanket implementations of `DelegateComponent` and `IsProviderFor` are also derived to inherit from the given preset provider.