### PR TITLE
Introduce `#[new_cgp_provider]` to also generate provider struct definition

### DIFF
--- a/crates/cgp-component-macro-lib/src/derive_context/derive.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/derive.rs
@@ -23,9 +23,9 @@ pub fn derive_context(attr: TokenStream, body: TokenStream) -> syn::Result<Token
         #has_components_impl
     };
 
-    if let Some((preset_name, preset_generics)) = &context_spec.preset {
+    if let Some(preset) = &context_spec.preset {
         let (delegate_impl, is_provider_impl) =
-            derive_delegate_preset(provider_name, preset_name, preset_generics);
+            derive_delegate_preset(provider_name, &preset.name, &preset.generics);
 
         Ok(quote! {
             #base_derived

--- a/crates/cgp-component-macro-lib/src/derive_context/spec.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/spec.rs
@@ -1,10 +1,12 @@
 use syn::parse::{Parse, ParseStream};
-use syn::token::{Colon, Lt};
-use syn::{AngleBracketedGenericArguments, Ident};
+use syn::token::Colon;
+use syn::Ident;
+
+use crate::parse::SimpleType;
 
 pub struct ContextSpec {
     pub provider_name: Ident,
-    pub preset: Option<(Ident, Option<AngleBracketedGenericArguments>)>,
+    pub preset: Option<SimpleType>,
 }
 
 impl Parse for ContextSpec {
@@ -14,16 +16,7 @@ impl Parse for ContextSpec {
         let colon: Option<Colon> = input.parse()?;
 
         let preset = match colon {
-            Some(_) => {
-                let preset_name: Ident = input.parse()?;
-                let preset_generics = if input.peek(Lt) {
-                    Some(input.parse()?)
-                } else {
-                    None
-                };
-
-                Some((preset_name, preset_generics))
-            }
+            Some(_) => Some(input.parse()?),
             None => None,
         };
 

--- a/crates/cgp-component-macro-lib/src/lib.rs
+++ b/crates/cgp-component-macro-lib/src/lib.rs
@@ -15,17 +15,17 @@ pub(crate) mod derive_context;
 pub(crate) mod derive_provider;
 pub(crate) mod for_each_replace;
 pub(crate) mod getter_component;
+pub(crate) mod parse;
 pub(crate) mod preset;
 pub(crate) mod type_component;
 
 #[cfg(test)]
 mod tests;
 
-pub use derive_provider::derive_provider;
-
 pub use crate::delegate_components::delegate_components;
 pub use crate::derive_component::derive_component;
 pub use crate::derive_context::derive_context;
+pub use crate::derive_provider::{derive_new_provider, derive_provider};
 pub use crate::for_each_replace::{handle_for_each_replace, handle_replace};
 pub use crate::getter_component::derive::{derive_auto_getter_component, derive_getter_component};
 pub use crate::preset::define_preset;

--- a/crates/cgp-component-macro-lib/src/parse/mod.rs
+++ b/crates/cgp-component-macro-lib/src/parse/mod.rs
@@ -1,0 +1,3 @@
+mod simple_type;
+
+pub use simple_type::*;

--- a/crates/cgp-component-macro-lib/src/parse/simple_type.rs
+++ b/crates/cgp-component-macro-lib/src/parse/simple_type.rs
@@ -1,0 +1,21 @@
+use syn::parse::{Parse, ParseStream};
+use syn::token::Lt;
+use syn::{AngleBracketedGenericArguments, Ident};
+
+pub struct SimpleType {
+    pub name: Ident,
+    pub generics: Option<AngleBracketedGenericArguments>,
+}
+
+impl Parse for SimpleType {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name: Ident = input.parse()?;
+        let generics = if input.peek(Lt) {
+            Some(input.parse()?)
+        } else {
+            None
+        };
+
+        Ok(Self { name, generics })
+    }
+}

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -23,6 +23,13 @@ pub fn cgp_provider(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn new_cgp_provider(attr: TokenStream, item: TokenStream) -> TokenStream {
+    cgp_component_macro_lib::derive_new_provider(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_attribute]
 pub fn cgp_getter(attr: TokenStream, item: TokenStream) -> TokenStream {
     cgp_component_macro_lib::derive_getter_component(attr.into(), item.into())
         .unwrap_or_else(syn::Error::into_compile_error)

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -12,8 +12,9 @@ description  = """
 """
 
 [features]
-default = [ "full" ]
-full = [ "cgp-async/full" ]
+default             = [ "full" ]
+full                = [ "cgp-async/full" ]
+provider-supertrait = [ "cgp-component-macro/provider-supertrait" ]
 
 [dependencies]
 cgp-async           = { version = "0.3.0", default-features = false }

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -5,7 +5,7 @@ pub use cgp_component::{
 };
 pub use cgp_component_macro::{
     cgp_auto_getter, cgp_component, cgp_context, cgp_getter, cgp_preset, cgp_provider, cgp_type,
-    delegate_components, for_each_replace, replace_with,
+    delegate_components, for_each_replace, new_cgp_provider, replace_with,
 };
 pub use cgp_error::{
     CanRaiseAsyncError, CanRaiseError, CanWrapAsyncError, CanWrapError, HasAsyncErrorType,

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -12,8 +12,9 @@ description  = """
 """
 
 [features]
-default = [ "full" ]
-full = [ "cgp-core/full", "cgp-extra/full" ]
+default             = [ "full" ]
+full                = [ "cgp-core/full", "cgp-extra/full" ]
+provider-supertrait = [ "cgp-core/provider-supertrait" ]
 
 [dependencies]
 cgp-async      = { version = "0.3.0", default-features = false }


### PR DESCRIPTION
Compared to `#[cgp_provider]`, the macro `#[new_cgp_provider]` also defines the `struct` definition of the provider, so that one do not need to define it manually.

This is mainly useful for providers which only implement one provider trait. When a provider implements more than one provider traits, one should still use `#[cgp_provider]` in the provider implementation.