### PR TITLE
Redesign `cgp_type` to work as attribute macro

### DIFF
--- a/crates/cgp-component-macro-lib/src/derive_component/component_spec.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/component_spec.rs
@@ -1,11 +1,12 @@
 use alloc::format;
+use std::collections::BTreeMap;
 
 use proc_macro2::Span;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::{Comma, Gt, Lt};
-use syn::{Error, Ident};
+use syn::{Error, Ident, Type};
 
 use crate::derive_component::entry::Entries;
 
@@ -23,63 +24,74 @@ pub struct ComponentNameSpec {
 
 static VALID_KEYS: [&str; 3] = ["context", "provider", "name"];
 
+pub fn validate_component_entries(entries: &BTreeMap<String, Type>) -> syn::Result<()> {
+    for key in entries.keys() {
+        if !VALID_KEYS.iter().any(|valid| valid == key) {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                format!(
+                    r#"invalid key in component spec: {key}. the following keys are valid: "context", "provider", "name"."#
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 impl Parse for ComponentSpec {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let Entries { entries } = input.parse()?;
-
-        for key in entries.keys() {
-            if !VALID_KEYS.iter().any(|valid| valid == key) {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    format!(
-                        r#"invalid key in component spec: {key}. the following keys are valid: "context", "provider", "name"."#
-                    ),
-                ));
-            }
-        }
-
-        let context_type: Ident = {
-            let raw_context_type = entries.get("context");
-
-            if let Some(context_type) = raw_context_type {
-                syn::parse2(context_type.to_token_stream())?
-            } else {
-                Ident::new("Context", Span::call_site())
-            }
-        };
-
-        let provider_name: Ident = {
-            let raw_provider_name = entries
-                .get("provider")
-                .ok_or_else(|| Error::new(input.span(), "expect provider name to be given"))?;
-
-            syn::parse2(raw_provider_name.to_token_stream())?
-        };
-
-        let (component_name, component_params) = {
-            let raw_component_name = entries.get("name");
-
-            if let Some(raw_component_name) = raw_component_name {
-                let ComponentNameSpec {
-                    component_name,
-                    component_params,
-                } = syn::parse2(raw_component_name.to_token_stream())?;
-                (component_name, component_params)
-            } else {
-                (
-                    Ident::new(&format!("{}Component", provider_name), provider_name.span()),
-                    Punctuated::default(),
-                )
-            }
-        };
-
-        Ok(ComponentSpec {
-            component_name,
-            provider_name,
-            context_type,
-            component_params,
-        })
+        parse_component_from_entries(&entries)
     }
+}
+
+pub fn parse_component_from_entries(
+    entries: &BTreeMap<String, Type>,
+) -> syn::Result<ComponentSpec> {
+    validate_component_entries(&entries)?;
+
+    let context_type: Ident = {
+        let raw_context_type = entries.get("context");
+
+        if let Some(context_type) = raw_context_type {
+            syn::parse2(context_type.to_token_stream())?
+        } else {
+            Ident::new("Context", Span::call_site())
+        }
+    };
+
+    let provider_name: Ident = {
+        let raw_provider_name = entries
+            .get("provider")
+            .ok_or_else(|| Error::new(Span::call_site(), "expect provider name to be given"))?;
+
+        syn::parse2(raw_provider_name.to_token_stream())?
+    };
+
+    let (component_name, component_params) = {
+        let raw_component_name = entries.get("name");
+
+        if let Some(raw_component_name) = raw_component_name {
+            let ComponentNameSpec {
+                component_name,
+                component_params,
+            } = syn::parse2(raw_component_name.to_token_stream())?;
+            (component_name, component_params)
+        } else {
+            (
+                Ident::new(&format!("{}Component", provider_name), provider_name.span()),
+                Punctuated::default(),
+            )
+        }
+    };
+
+    Ok(ComponentSpec {
+        component_name,
+        provider_name,
+        context_type,
+        component_params,
+    })
 }
 
 impl Parse for ComponentNameSpec {

--- a/crates/cgp-component-macro-lib/src/derive_component/component_spec.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/component_spec.rs
@@ -49,7 +49,7 @@ impl Parse for ComponentSpec {
 pub fn parse_component_from_entries(
     entries: &BTreeMap<String, Type>,
 ) -> syn::Result<ComponentSpec> {
-    validate_component_entries(&entries)?;
+    validate_component_entries(entries)?;
 
     let context_type: Ident = {
         let raw_context_type = entries.get("context");

--- a/crates/cgp-component-macro-lib/src/derive_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/derive.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::ToTokens;
 use syn::{ItemImpl, ItemStruct, ItemTrait};
 
 use crate::derive_component::component_name::derive_component_name_struct;

--- a/crates/cgp-component-macro-lib/src/derive_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/derive.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::ItemTrait;
+use quote::{quote, ToTokens};
+use syn::{ItemImpl, ItemStruct, ItemTrait};
 
 use crate::derive_component::component_name::derive_component_name_struct;
 use crate::derive_component::component_spec::ComponentSpec;
@@ -12,13 +12,15 @@ pub fn derive_component(attr: TokenStream, item: TokenStream) -> syn::Result<Tok
     let spec: ComponentSpec = syn::parse2(attr)?;
     let consumer_trait: ItemTrait = syn::parse2(item)?;
 
-    derive_component_with_ast(&spec, &consumer_trait)
+    let derived = derive_component_with_ast(&spec, consumer_trait)?;
+
+    Ok(derived.to_token_stream())
 }
 
 pub fn derive_component_with_ast(
     spec: &ComponentSpec,
-    consumer_trait: &ItemTrait,
-) -> syn::Result<TokenStream> {
+    consumer_trait: ItemTrait,
+) -> syn::Result<DerivedComponent> {
     let provider_name = &spec.provider_name;
     let context_type = &spec.context_type;
 
@@ -28,28 +30,46 @@ pub fn derive_component_with_ast(
     let provider_trait = derive_provider_trait(
         &spec.component_name,
         &spec.component_params,
-        consumer_trait,
+        &consumer_trait,
         provider_name,
         context_type,
     )?;
 
-    let consumer_impl = derive_consumer_impl(consumer_trait, provider_name, context_type);
+    let consumer_impl = derive_consumer_impl(&consumer_trait, provider_name, context_type);
 
     let provider_impl = derive_provider_impl(
         context_type,
-        consumer_trait,
+        &consumer_trait,
         &provider_trait,
         &spec.component_name,
         &spec.component_params,
     );
 
-    let derived = quote! {
-        #consumer_trait
-        #component_struct
-        #provider_trait
-        #consumer_impl
-        #provider_impl
+    let derived = DerivedComponent {
+        component_struct,
+        consumer_trait,
+        provider_trait,
+        consumer_impl,
+        provider_impl,
     };
 
     Ok(derived)
+}
+
+pub struct DerivedComponent {
+    pub component_struct: ItemStruct,
+    pub consumer_trait: ItemTrait,
+    pub provider_trait: ItemTrait,
+    pub consumer_impl: ItemImpl,
+    pub provider_impl: ItemImpl,
+}
+
+impl ToTokens for DerivedComponent {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.component_struct.to_tokens(tokens);
+        self.consumer_trait.to_tokens(tokens);
+        self.provider_trait.to_tokens(tokens);
+        self.consumer_impl.to_tokens(tokens);
+        self.provider_impl.to_tokens(tokens);
+    }
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/derive.rs
@@ -16,7 +16,7 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
     let spec: ComponentSpec = syn::parse2(attr)?;
     let consumer_trait: ItemTrait = syn::parse2(body)?;
 
-    let derived_component = derive_component_with_ast(&spec, &consumer_trait)?;
+    let derived_component = derive_component_with_ast(&spec, consumer_trait.clone())?;
 
     let fields = parse_getter_fields(&spec.context_type, &consumer_trait)?;
 

--- a/crates/cgp-component-macro-lib/src/tests/derive_component.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_component.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
 use crate::derive_component::derive::derive_component;
-use crate::tests::helper::equal::equal_token_stream;
+use crate::tests::helper::equal::assert_equal_token_stream;
 
 #[test]
 fn test_basic_derive_component() {
@@ -40,13 +40,13 @@ fn test_derive_component_with_const_generic() {
     .unwrap();
 
     let expected = quote! {
+        pub struct FooComponent;
+
         pub trait HasFoo<const BAR: usize> {
             type Foo;
 
             fn foo(&self) -> Self::Foo;
         }
-
-        pub struct FooComponent;
 
         pub trait FooProvider<Context, const BAR: usize>: IsProviderFor<FooComponent, Context, (BAR)> {
             type Foo;
@@ -79,7 +79,7 @@ fn test_derive_component_with_const_generic() {
         }
     };
 
-    assert!(equal_token_stream(&derived, &expected));
+    assert_equal_token_stream(&derived, &expected);
 }
 
 #[cfg(not(feature = "provider-supertrait"))]
@@ -101,13 +101,13 @@ fn test_derive_component_with_const_generic() {
     .unwrap();
 
     let expected = quote! {
+        pub struct FooComponent;
+
         pub trait HasFoo<const BAR: usize> {
             type Foo;
 
             fn foo(&self) -> Self::Foo;
         }
-
-        pub struct FooComponent;
 
         pub trait FooProvider<Context, const BAR: usize> {
             type Foo;
@@ -140,5 +140,5 @@ fn test_derive_component_with_const_generic() {
         }
     };
 
-    assert!(equal_token_stream(&derived, &expected));
+    assert_equal_token_stream(&derived, &expected);
 }

--- a/crates/cgp-component-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/type_component/derive.rs
@@ -2,18 +2,102 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::token::{Colon, Plus, Pound};
-use syn::{parse_quote, Attribute, Ident, ItemImpl, ItemTrait, ItemType, TypeParamBound};
+use syn::{
+    parse2, parse_quote, Attribute, Error, Generics, Ident, ItemImpl, ItemTrait, ItemType,
+    TraitItem, TraitItemType, TypeParamBound,
+};
 
+use crate::derive_component::component_spec::{
+    parse_component_from_entries, validate_component_entries, ComponentSpec,
+};
+use crate::derive_component::derive::{derive_component_with_ast, DerivedComponent};
+use crate::derive_component::entry::Entries;
 use crate::derive_provider::derive_is_provider_for;
 
-pub fn derive_type_component(stream: TokenStream) -> syn::Result<TokenStream> {
-    let spec: TypeComponentSpecs = syn::parse2(stream)?;
+pub fn derive_type_component(attrs: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+    let Entries { mut entries } = syn::parse2(attrs)?;
 
-    do_derive_type_component(spec.attributes, spec.ident, spec.bounds)
+    let consumer_trait: ItemTrait = syn::parse2(body)?;
+
+    let item_type = extract_item_type(&consumer_trait)?.clone();
+
+    entries.entry("provider".into()).or_insert_with(|| {
+        let provider_name = Ident::new(
+            &format!("{}TypeProvider", item_type.ident),
+            item_type.ident.span(),
+        );
+        parse_quote!( #provider_name )
+    });
+
+    let spec = parse_component_from_entries(&entries)?;
+
+    let component = derive_component_with_ast(&spec, consumer_trait)?;
+
+    let alias_type = derive_type_alias(&component, &spec.context_type, &item_type)?;
+
+    Ok(quote! {
+        #component
+
+        #alias_type
+    })
+}
+
+pub fn extract_item_type(consumer_trait: &ItemTrait) -> syn::Result<&TraitItemType> {
+    if consumer_trait.items.len() != 1 {
+        return Err(Error::new(
+            consumer_trait.span(),
+            "type trait should contain exactly one associated type item",
+        ));
+    }
+
+    match consumer_trait.items.get(0) {
+        Some(TraitItem::Type(item_type)) => {
+            if !item_type.generics.params.is_empty() || item_type.generics.where_clause.is_some() {
+                return Err(Error::new(
+                    consumer_trait.span(),
+                    "generic associated type and where clause are not supported",
+                ));
+            }
+
+            Ok(item_type)
+        }
+        _ => Err(Error::new(
+            consumer_trait.span(),
+            "type trait should contain exactly one associated type item",
+        )),
+    }
+}
+
+pub fn derive_type_alias(
+    component: &DerivedComponent,
+    context_name: &Ident,
+    item_type: &TraitItemType,
+) -> syn::Result<ItemType> {
+    let consumer_trait_name = &component.consumer_trait.ident;
+
+    let (impl_generics, type_generics, where_clause) =
+        component.consumer_trait.generics.split_for_impl();
+
+    let impl_generics: Generics = parse2(impl_generics.to_token_stream())?;
+    let type_generics: Generics = parse2(type_generics.to_token_stream())?;
+
+    let impl_generics_params = &impl_generics.params;
+    let type_generics_params = &type_generics.params;
+
+    let type_name = &item_type.ident;
+    let alias_name = Ident::new(&format!("{}Of", type_name), type_name.span());
+
+    let alias_type: ItemType = parse2(quote! {
+        pub type #alias_name < #context_name, #type_generics_params > =
+            < #context_name as #consumer_trait_name #type_generics > :: #type_name ;
+    })?;
+
+    Ok(alias_type)
 }
 
 pub struct TypeComponentSpecs {

--- a/crates/cgp-component-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/type_component/derive.rs
@@ -38,12 +38,16 @@ pub fn derive_type_component(attrs: TokenStream, body: TokenStream) -> syn::Resu
 
     let component = derive_component_with_ast(&spec, consumer_trait)?;
 
-    let alias_type = derive_type_alias(&component, &spec.context_type, &item_type)?;
+    let alias_type = derive_type_alias(&component.consumer_trait, &spec.context_type, &item_type)?;
+
+    let use_type_impl = derive_use_type_impl(&component.provider_trait, &item_type)?;
 
     Ok(quote! {
         #component
 
         #alias_type
+
+        #use_type_impl
     })
 }
 
@@ -74,19 +78,16 @@ pub fn extract_item_type(consumer_trait: &ItemTrait) -> syn::Result<&TraitItemTy
 }
 
 pub fn derive_type_alias(
-    component: &DerivedComponent,
+    consumer_trait: &ItemTrait,
     context_name: &Ident,
     item_type: &TraitItemType,
 ) -> syn::Result<ItemType> {
-    let consumer_trait_name = &component.consumer_trait.ident;
+    let consumer_trait_name = &consumer_trait.ident;
 
-    let (impl_generics, type_generics, where_clause) =
-        component.consumer_trait.generics.split_for_impl();
+    let (_, type_generics, _) = consumer_trait.generics.split_for_impl();
 
-    let impl_generics: Generics = parse2(impl_generics.to_token_stream())?;
     let type_generics: Generics = parse2(type_generics.to_token_stream())?;
 
-    let impl_generics_params = &impl_generics.params;
     let type_generics_params = &type_generics.params;
 
     let type_name = &item_type.ident;
@@ -98,6 +99,47 @@ pub fn derive_type_alias(
     })?;
 
     Ok(alias_type)
+}
+
+pub fn derive_use_type_impl(
+    provider_trait: &ItemTrait,
+    item_type: &TraitItemType,
+) -> syn::Result<ItemImpl> {
+    let provider_trait_name = &provider_trait.ident;
+
+    let (impl_generics, type_generics, where_clause) = provider_trait.generics.split_for_impl();
+
+    let impl_generics_params = parse2::<Generics>(impl_generics.to_token_stream())?.params;
+
+    let predicates = where_clause
+        .map(|c| c.predicates.clone())
+        .unwrap_or_default();
+
+    let type_name = &item_type.ident;
+
+    let type_bounds = if item_type.bounds.is_empty() {
+        TokenStream::new()
+    } else {
+        let bounds = &item_type.bounds;
+
+        quote! {
+            #type_name: #bounds,
+        }
+    };
+
+    let use_type_impl: ItemImpl = parse2(quote! {
+        impl< #type_name, #impl_generics_params >
+            #provider_trait_name #type_generics
+            for UseType< #type_name >
+        where
+            #type_bounds
+            #predicates
+        {
+            type #type_name = #type_name;
+        }
+    })?;
+
+    Ok(use_type_impl)
 }
 
 pub struct TypeComponentSpecs {

--- a/crates/cgp-component-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/type_component/derive.rs
@@ -56,7 +56,7 @@ pub fn extract_item_type(consumer_trait: &ItemTrait) -> syn::Result<&TraitItemTy
         ));
     }
 
-    match consumer_trait.items.get(0) {
+    match consumer_trait.items.first() {
         Some(TraitItem::Type(item_type)) => {
             if !item_type.generics.params.is_empty() || item_type.generics.where_clause.is_some() {
                 return Err(Error::new(

--- a/crates/cgp-component-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/type_component/derive.rs
@@ -3,20 +3,14 @@ use alloc::vec::Vec;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::token::{Colon, Plus, Pound};
 use syn::{
-    parse2, parse_quote, Attribute, Error, Generics, Ident, ItemImpl, ItemTrait, ItemType,
-    TraitItem, TraitItemType, Type, TypeParamBound,
+    parse2, parse_quote, Error, Generics, Ident, ItemImpl, ItemTrait, ItemType, TraitItem,
+    TraitItemType, Type,
 };
 
-use crate::delegate_components::ast::ComponentAst;
-use crate::derive_component::component_spec::{
-    parse_component_from_entries, validate_component_entries, ComponentSpec,
-};
-use crate::derive_component::derive::{derive_component_with_ast, DerivedComponent};
+use crate::derive_component::component_spec::{parse_component_from_entries, ComponentSpec};
+use crate::derive_component::derive::derive_component_with_ast;
 use crate::derive_component::entry::Entries;
 use crate::derive_provider::derive_is_provider_for;
 
@@ -167,147 +161,4 @@ pub fn derive_type_providers(
         with_provider_impl,
         with_provider_is_provider_impl,
     ])
-}
-
-pub struct TypeComponentSpecs {
-    pub attributes: Vec<Attribute>,
-    pub ident: Ident,
-    pub bounds: Punctuated<TypeParamBound, Plus>,
-}
-
-impl Parse for TypeComponentSpecs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let attributes = {
-            let lookahead = input.lookahead1();
-            if lookahead.peek(Pound) {
-                input.call(Attribute::parse_outer)?
-            } else {
-                Vec::new()
-            }
-        };
-
-        let ident = input.parse()?;
-
-        if input.is_empty() {
-            return Ok(Self {
-                attributes,
-                ident,
-                bounds: Punctuated::new(),
-            });
-        }
-
-        let _: Colon = input.parse()?;
-
-        let bounds = input.parse_terminated(TypeParamBound::parse, Plus)?;
-
-        Ok(Self {
-            attributes,
-            ident,
-            bounds,
-        })
-    }
-}
-
-pub fn do_derive_type_component(
-    attributes: Vec<Attribute>,
-    ident: Ident,
-    bounds: Punctuated<TypeParamBound, Plus>,
-) -> syn::Result<TokenStream> {
-    let consumer_trait_name = Ident::new(&format!("Has{ident}Type"), ident.span());
-
-    let provider_trait_name = Ident::new(&format!("Provide{ident}Type"), ident.span());
-
-    let alias_name = Ident::new(&format!("{ident}Of"), ident.span());
-
-    let component_name = Ident::new(&format!("{ident}TypeComponent"), ident.span());
-
-    let alias_type: ItemType = parse_quote! {
-        pub type #alias_name <__Context__> = <__Context__ as #consumer_trait_name>:: #ident;
-    };
-
-    let mut consumer_trait: ItemTrait = parse_quote! {
-        pub trait #consumer_trait_name {
-            type #ident : #bounds ;
-        }
-    };
-
-    consumer_trait.attrs = attributes;
-
-    let provider_trait: ItemTrait = parse_quote! {
-        pub trait #provider_trait_name <__Context__> {
-            type #ident : #bounds;
-        }
-    };
-
-    let consumer_impl: ItemImpl = parse_quote! {
-        impl<__Context__, __Components__> #consumer_trait_name for __Context__
-        where
-            __Context__: HasComponents< Components = __Components__ >,
-            __Components__: #provider_trait_name <__Context__>,
-            __Components__:: #ident : #bounds,
-        {
-            type #ident = __Components__:: #ident;
-        }
-    };
-
-    let provider_impl: ItemImpl = parse_quote! {
-        impl<__Context__, Component, Delegate>
-            #provider_trait_name <__Context__> for Component
-        where
-            Component: DelegateComponent< #component_name, Delegate = Delegate >,
-            Delegate: #provider_trait_name <__Context__>,
-            Delegate:: #ident : #bounds,
-        {
-            type #ident = Delegate:: #ident;
-        }
-    };
-
-    let with_provider_impl: ItemImpl = parse_quote! {
-        impl<__Context__, Provider, #ident> #provider_trait_name <__Context__>
-            for WithProvider<Provider>
-        where
-            Provider: ProvideType<__Context__, #component_name, Type = #ident >,
-            #ident: #bounds,
-        {
-            type #ident = #ident;
-        }
-    };
-
-    let is_provider_for_with_provider_impl =
-        derive_is_provider_for(&parse_quote!(#component_name), &with_provider_impl)?;
-
-    let use_type_impl: ItemImpl = parse_quote! {
-        impl<__Context__, #ident> #provider_trait_name <__Context__>
-            for UseType<#ident>
-        where
-            #ident: #bounds,
-        {
-            type #ident = #ident;
-        }
-    };
-
-    let is_provider_for_use_type_impl =
-        derive_is_provider_for(&parse_quote!(#component_name), &use_type_impl)?;
-
-    Ok(quote! {
-        pub struct #component_name;
-
-        #consumer_trait
-
-        #alias_type
-
-        #provider_trait
-
-        #consumer_impl
-
-        #provider_impl
-
-        #with_provider_impl
-
-        #is_provider_for_with_provider_impl
-
-        #use_type_impl
-
-        #is_provider_for_use_type_impl
-    })
 }

--- a/crates/cgp-component-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/type_component/derive.rs
@@ -2,16 +2,17 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::{Colon, Plus, Pound};
 use syn::{
     parse2, parse_quote, Attribute, Error, Generics, Ident, ItemImpl, ItemTrait, ItemType,
-    TraitItem, TraitItemType, TypeParamBound,
+    TraitItem, TraitItemType, Type, TypeParamBound,
 };
 
+use crate::delegate_components::ast::ComponentAst;
 use crate::derive_component::component_spec::{
     parse_component_from_entries, validate_component_entries, ComponentSpec,
 };
@@ -40,15 +41,17 @@ pub fn derive_type_component(attrs: TokenStream, body: TokenStream) -> syn::Resu
 
     let alias_type = derive_type_alias(&component.consumer_trait, &spec.context_type, &item_type)?;
 
-    let use_type_impl = derive_use_type_impl(&component.provider_trait, &item_type)?;
+    let type_provider_impls = derive_type_providers(&spec, &component.provider_trait, &item_type)?;
 
-    Ok(quote! {
+    let mut out = quote! {
         #component
 
         #alias_type
+    };
 
-        #use_type_impl
-    })
+    out.append_all(type_provider_impls);
+
+    Ok(out)
 }
 
 pub fn extract_item_type(consumer_trait: &ItemTrait) -> syn::Result<&TraitItemType> {
@@ -101,10 +104,19 @@ pub fn derive_type_alias(
     Ok(alias_type)
 }
 
-pub fn derive_use_type_impl(
+pub fn derive_type_providers(
+    spec: &ComponentSpec,
     provider_trait: &ItemTrait,
     item_type: &TraitItemType,
-) -> syn::Result<ItemImpl> {
+) -> syn::Result<Vec<ItemImpl>> {
+    let context_name = &spec.context_type;
+
+    let component_name = {
+        let name = &spec.component_name;
+        let params = &spec.component_params;
+        parse2::<Type>(quote! { #name < #params > })
+    }?;
+
     let provider_trait_name = &provider_trait.ident;
 
     let (impl_generics, type_generics, where_clause) = provider_trait.generics.split_for_impl();
@@ -117,29 +129,44 @@ pub fn derive_use_type_impl(
 
     let type_name = &item_type.ident;
 
-    let type_bounds = if item_type.bounds.is_empty() {
-        TokenStream::new()
-    } else {
-        let bounds = &item_type.bounds;
-
-        quote! {
-            #type_name: #bounds,
-        }
-    };
+    let type_bounds = &item_type.bounds;
 
     let use_type_impl: ItemImpl = parse2(quote! {
         impl< #type_name, #impl_generics_params >
             #provider_trait_name #type_generics
             for UseType< #type_name >
         where
-            #type_bounds
+            #type_name: #type_bounds,
             #predicates
         {
             type #type_name = #type_name;
         }
     })?;
 
-    Ok(use_type_impl)
+    let use_type_is_provider_impl = derive_is_provider_for(&component_name, &use_type_impl)?;
+
+    let with_provider_impl: ItemImpl = parse2(quote! {
+        impl< __Provider__, #impl_generics_params >
+            #provider_trait_name #type_generics
+            for WithProvider< __Provider__ >
+        where
+            __Provider__: ProvideType< #context_name, #component_name >,
+            __Provider__::Type: #type_bounds,
+            #predicates
+        {
+            type #type_name = __Provider__::Type;
+        }
+    })?;
+
+    let with_provider_is_provider_impl =
+        derive_is_provider_for(&component_name, &with_provider_impl)?;
+
+    Ok(vec![
+        use_type_impl,
+        use_type_is_provider_impl,
+        with_provider_impl,
+        with_provider_is_provider_impl,
+    ])
 }
 
 pub struct TypeComponentSpecs {

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -57,9 +57,9 @@ pub fn cgp_preset(body: TokenStream) -> TokenStream {
         .into()
 }
 
-#[proc_macro]
-pub fn cgp_type(body: TokenStream) -> TokenStream {
-    cgp_component_macro_lib::derive_type_component(body.into())
+#[proc_macro_attribute]
+pub fn cgp_type(attrs: TokenStream, body: TokenStream) -> TokenStream {
+    cgp_component_macro_lib::derive_type_component(attrs.into(), body.into())
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/crates/cgp-error-anyhow/src/impls/use_anyhow_error.rs
+++ b/crates/cgp-error-anyhow/src/impls/use_anyhow_error.rs
@@ -1,8 +1,10 @@
 use anyhow::Error;
-use cgp_core::error::ProvideErrorType;
+use cgp_core::error::{ErrorTypeProvider, ErrorTypeProviderComponent};
+use cgp_core::prelude::*;
 
 pub struct UseAnyhowError;
 
-impl<Context> ProvideErrorType<Context> for UseAnyhowError {
+#[cgp_provider(ErrorTypeProviderComponent)]
+impl<Context> ErrorTypeProvider<Context> for UseAnyhowError {
     type Error = Error;
 }

--- a/crates/cgp-error-eyre/src/impls/use_eyre_error.rs
+++ b/crates/cgp-error-eyre/src/impls/use_eyre_error.rs
@@ -1,8 +1,8 @@
-use cgp_core::error::ProvideErrorType;
+use cgp_core::error::ErrorTypeProvider;
 use eyre::Error;
 
 pub struct UseEyreError;
 
-impl<Context> ProvideErrorType<Context> for UseEyreError {
+impl<Context> ErrorTypeProvider<Context> for UseEyreError {
     type Error = Error;
 }

--- a/crates/cgp-error-eyre/src/impls/use_eyre_error.rs
+++ b/crates/cgp-error-eyre/src/impls/use_eyre_error.rs
@@ -1,8 +1,10 @@
-use cgp_core::error::ErrorTypeProvider;
+use cgp_core::error::{ErrorTypeProvider, ErrorTypeProviderComponent};
+use cgp_core::prelude::*;
 use eyre::Error;
 
 pub struct UseEyreError;
 
+#[cgp_provider(ErrorTypeProviderComponent)]
 impl<Context> ErrorTypeProvider<Context> for UseEyreError {
     type Error = Error;
 }

--- a/crates/cgp-error-std/src/impls/use_boxed.rs
+++ b/crates/cgp-error-std/src/impls/use_boxed.rs
@@ -1,9 +1,9 @@
-use cgp_core::error::ProvideErrorType;
+use cgp_core::error::ErrorTypeProvider;
 
 use crate::types::Error;
 
 pub struct UseBoxedStdError;
 
-impl<Context> ProvideErrorType<Context> for UseBoxedStdError {
+impl<Context> ErrorTypeProvider<Context> for UseBoxedStdError {
     type Error = Error;
 }

--- a/crates/cgp-error-std/src/impls/use_boxed.rs
+++ b/crates/cgp-error-std/src/impls/use_boxed.rs
@@ -1,9 +1,11 @@
-use cgp_core::error::ErrorTypeProvider;
+use cgp_core::error::{ErrorTypeProvider, ErrorTypeProviderComponent};
+use cgp_core::prelude::*;
 
 use crate::types::Error;
 
 pub struct UseBoxedStdError;
 
+#[cgp_provider(ErrorTypeProviderComponent)]
 impl<Context> ErrorTypeProvider<Context> for UseBoxedStdError {
     type Error = Error;
 }

--- a/crates/cgp-error/src/lib.rs
+++ b/crates/cgp-error/src/lib.rs
@@ -4,6 +4,6 @@ mod traits;
 
 pub use traits::{
     CanRaiseAsyncError, CanRaiseError, CanWrapAsyncError, CanWrapError, ErrorOf, ErrorRaiser,
-    ErrorRaiserComponent, ErrorTypeComponent, ErrorWrapper, ErrorWrapperComponent,
-    HasAsyncErrorType, HasErrorType, ProvideErrorType,
+    ErrorRaiserComponent, ErrorTypeProvider, ErrorTypeProviderComponent, ErrorWrapper,
+    ErrorWrapperComponent, HasAsyncErrorType, HasErrorType,
 };

--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -4,24 +4,25 @@ use cgp_component::{DelegateComponent, HasComponents, IsProviderFor, WithProvide
 use cgp_component_macro::cgp_type;
 use cgp_type::{ProvideType, UseType};
 
-cgp_type! {
-    /**
-        This is used for contexts to declare that they have a _unique_ `Self::Error` type.
+/**
+    This is used for contexts to declare that they have a _unique_ `Self::Error` type.
 
-        Although it is possible for each context to declare their own associated
-        `Error` type, doing so may result in having multiple ambiguous `Self::Error` types,
-        if there are multiple associated types with the same name in different traits.
+    Although it is possible for each context to declare their own associated
+    `Error` type, doing so may result in having multiple ambiguous `Self::Error` types,
+    if there are multiple associated types with the same name in different traits.
 
-        As a result, it is better for context traits to include `HasError` as their
-        parent traits, so that multiple traits can all refer to the same abstract
-        `Self::Error` type.
+    As a result, it is better for context traits to include `HasError` as their
+    parent traits, so that multiple traits can all refer to the same abstract
+    `Self::Error` type.
 
-       The `Error` associated type is also required to implement [`Debug`].
-       This is to allow `Self::Error` to be used in calls like `.unwrap()`,
-       as well as for simpler error logging.
+   The `Error` associated type is also required to implement [`Debug`].
+   This is to allow `Self::Error` to be used in calls like `.unwrap()`,
+   as well as for simpler error logging.
 
-       More details about how to use `HasErrorType` is available at
-       <https://patterns.contextgeneric.dev/error-handling.html>
-    */
-    Error: Debug
+   More details about how to use `HasErrorType` is available at
+   <https://patterns.contextgeneric.dev/error-handling.html>
+*/
+#[cgp_type]
+pub trait HasErrorType {
+    type Error: Debug;
 }

--- a/crates/cgp-error/src/traits/mod.rs
+++ b/crates/cgp-error/src/traits/mod.rs
@@ -6,4 +6,4 @@ mod has_error_type;
 pub use can_raise_error::{CanRaiseError, ErrorRaiser, ErrorRaiserComponent};
 pub use can_wrap_error::{CanWrapError, ErrorWrapper, ErrorWrapperComponent};
 pub use has_async_error_type::{CanRaiseAsyncError, CanWrapAsyncError, HasAsyncErrorType};
-pub use has_error_type::{ErrorOf, ErrorTypeComponent, HasErrorType, ProvideErrorType};
+pub use has_error_type::{ErrorOf, ErrorTypeProvider, ErrorTypeProviderComponent, HasErrorType};

--- a/crates/cgp-runtime/src/lib.rs
+++ b/crates/cgp-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 mod traits;
 
 pub use traits::{
-    HasAsyncRuntimeType, HasRuntime, HasRuntimeType, ProvideRuntimeType, RuntimeGetter,
-    RuntimeGetterComponent, RuntimeOf, RuntimeTypeComponent,
+    HasAsyncRuntimeType, HasRuntime, HasRuntimeType, RuntimeGetter, RuntimeGetterComponent,
+    RuntimeOf, RuntimeTypeProvider, RuntimeTypeProviderComponent,
 };

--- a/crates/cgp-runtime/src/traits/has_runtime_type.rs
+++ b/crates/cgp-runtime/src/traits/has_runtime_type.rs
@@ -1,5 +1,6 @@
 use cgp_core::prelude::*;
 
-cgp_type! {
-    Runtime
+#[cgp_type]
+pub trait HasRuntimeType {
+    type Runtime;
 }

--- a/crates/cgp-runtime/src/traits/mod.rs
+++ b/crates/cgp-runtime/src/traits/mod.rs
@@ -4,4 +4,6 @@ mod has_runtime_type;
 
 pub use has_async_runtime::HasAsyncRuntimeType;
 pub use has_runtime::{HasRuntime, RuntimeGetter, RuntimeGetterComponent};
-pub use has_runtime_type::{HasRuntimeType, ProvideRuntimeType, RuntimeOf, RuntimeTypeComponent};
+pub use has_runtime_type::{
+    HasRuntimeType, RuntimeOf, RuntimeTypeProvider, RuntimeTypeProviderComponent,
+};


### PR DESCRIPTION
This PR redesigns the `cgp_type` macro to make it an attribute macro following the same syntax as `cgp_component`. This is to allow for more complex CGP type components to be defined using the same macro, which may include generic parameters or super traits on the consumer trait.

The main change is as follows:

Before:

```rust
cgp_type!( Name: Display );
```

After:

```rust
#[cgp_type]
pub trait HasNameType {
  type Name: Display;
}
```


This PR also changes the implicit naming convention for the provider and component names. If no parameter is specified, `cgp_type` would use `{Type}TypeProvider` as the provider name, and `{Type}TypeProviderComponent` as the component name. So the above definition can also be made explicit with:

```rust
#[cgp_type {
    name: NameTypeProviderComponent,
    provider: NameTypeProvider,
}]
pub trait HasNameType {
  type Name: Display;
}
```