### PR TITLE
Rename `HasComponents` trait to `HasProvider`

### DIFF
--- a/crates/cgp-component-macro-lib/src/derive_component/consumer_impl.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/consumer_impl.rs
@@ -72,7 +72,7 @@ pub fn derive_consumer_impl(
 
         {
             let has_component_constraint: Punctuated<TypeParamBound, Plus> = parse_quote! {
-                HasComponents
+                HasProvider
             };
 
             let provider_constraint: Punctuated<TypeParamBound, Plus> = parse_quote! {
@@ -86,14 +86,14 @@ pub fn derive_consumer_impl(
                     });
 
                     where_clause.predicates.push(parse_quote! {
-                        #context_type :: Components : #provider_constraint
+                        #context_type :: Provider : #provider_constraint
                     });
                 }
                 _ => {
                     impl_generics.where_clause = Some(parse_quote! {
                         where
                             #context_type : #has_component_constraint,
-                            #context_type :: Components : #provider_constraint
+                            #context_type :: Provider : #provider_constraint
                     });
                 }
             }
@@ -109,7 +109,7 @@ pub fn derive_consumer_impl(
             TraitItem::Fn(trait_fn) => {
                 let impl_fn = derive_delegated_fn_impl(
                     &trait_fn.sig,
-                    &parse_quote!(#context_type :: Components),
+                    &parse_quote!(#context_type :: Provider),
                 );
 
                 impl_items.push(ImplItem::Fn(impl_fn));
@@ -132,7 +132,7 @@ pub fn derive_consumer_impl(
                 let impl_type = derive_delegate_type_impl(
                     trait_type,
                     parse_quote!(
-                        < #context_type :: Components as #provider_name < #provider_generic_args > > :: #type_name #type_generics
+                        < #context_type :: Provider as #provider_name < #provider_generic_args > > :: #type_name #type_generics
                     ),
                 );
 

--- a/crates/cgp-component-macro-lib/src/derive_context/derive.rs
+++ b/crates/cgp-component-macro-lib/src/derive_context/derive.rs
@@ -45,10 +45,10 @@ pub fn derive_has_components(provider_name: &Ident, context_struct: &ItemStruct)
     let (impl_generics, ty_generics, where_clause) = context_struct.generics.split_for_impl();
 
     parse_quote! {
-        impl #impl_generics HasComponents for #context_name #ty_generics
+        impl #impl_generics HasProvider for #context_name #ty_generics
             #where_clause
         {
-            type Components = #provider_name;
+            type Provider = #provider_name;
         }
     }
 }

--- a/crates/cgp-component-macro-lib/src/tests/derive_component.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_component.rs
@@ -56,13 +56,13 @@ fn test_derive_component_with_const_generic() {
 
         impl<Context, const BAR: usize> HasFoo<BAR> for Context
         where
-            Context: HasComponents,
-            Context::Components: FooProvider<Context, BAR>,
+            Context: HasProvider,
+            Context::Provider: FooProvider<Context, BAR>,
         {
-            type Foo = <Context::Components as FooProvider<Context, BAR>>::Foo;
+            type Foo = <Context::Provider as FooProvider<Context, BAR>>::Foo;
 
             fn foo(&self) -> Self::Foo {
-                Context::Components::foo(self)
+                Context::Provider::foo(self)
             }
         }
 
@@ -117,13 +117,13 @@ fn test_derive_component_with_const_generic() {
 
         impl<Context, const BAR: usize> HasFoo<BAR> for Context
         where
-            Context: HasComponents,
-            Context::Components: FooProvider<Context, BAR>,
+            Context: HasProvider,
+            Context::Provider: FooProvider<Context, BAR>,
         {
-            type Foo = <Context::Components as FooProvider<Context, BAR>>::Foo;
+            type Foo = <Context::Provider as FooProvider<Context, BAR>>::Foo;
 
             fn foo(&self) -> Self::Foo {
-                Context::Components::foo(self)
+                Context::Provider::foo(self)
             }
         }
 

--- a/crates/cgp-component-macro-lib/src/tests/derive_context.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_context.rs
@@ -29,11 +29,11 @@ fn test_basic_derive_context() {
 
         pub struct FooComponents;
 
-        impl<Bar: BarConstraint> HasComponents for FooContext<Bar>
+        impl<Bar: BarConstraint> HasProvider for FooContext<Bar>
         where
             Bar: BazConstraint,
         {
-            type Components = FooComponents;
+            type Provider = FooComponents;
         }
     };
 
@@ -67,11 +67,11 @@ fn test_derive_context_with_preset() {
 
         pub struct FooComponents;
 
-        impl<Bar: BarConstraint> HasComponents for FooContext<Bar>
+        impl<Bar: BarConstraint> HasProvider for FooContext<Bar>
         where
             Bar: BazConstraint,
         {
-            type Components = FooComponents;
+            type Provider = FooComponents;
         }
 
         impl<__Name__> DelegateComponent<__Name__> for FooComponents

--- a/crates/cgp-component/src/lib.rs
+++ b/crates/cgp-component/src/lib.rs
@@ -1,11 +1,11 @@
 #![no_std]
 
 /*!
-   This crate defines the core CGP traits, [`DelegateComponent`] and [`HasComponents`].
+   This crate defines the core CGP traits, [`DelegateComponent`] and [`HasProvider`].
 */
 
 mod traits;
 mod types;
 
-pub use traits::{CanUseComponent, DelegateComponent, HasComponents, IsProviderFor};
+pub use traits::{CanUseComponent, DelegateComponent, HasProvider, IsProviderFor};
 pub use types::{UseContext, UseDelegate, UseFields, WithContext, WithProvider};

--- a/crates/cgp-component/src/traits/can_use_component.rs
+++ b/crates/cgp-component/src/traits/can_use_component.rs
@@ -1,10 +1,10 @@
-use crate::{HasComponents, IsProviderFor};
+use crate::{HasProvider, IsProviderFor};
 
 pub trait CanUseComponent<Component, Params = ()> {}
 
 impl<Context, Component, Params> CanUseComponent<Component, Params> for Context
 where
-    Context: HasComponents,
-    Context::Components: IsProviderFor<Component, Context, Params>,
+    Context: HasProvider,
+    Context::Provider: IsProviderFor<Component, Context, Params>,
 {
 }

--- a/crates/cgp-component/src/traits/has_components.rs
+++ b/crates/cgp-component/src/traits/has_components.rs
@@ -1,3 +1,3 @@
-pub trait HasComponents {
-    type Components;
+pub trait HasProvider {
+    type Provider;
 }

--- a/crates/cgp-component/src/traits/mod.rs
+++ b/crates/cgp-component/src/traits/mod.rs
@@ -5,5 +5,5 @@ mod is_provider;
 
 pub use can_use_component::*;
 pub use delegate_component::DelegateComponent;
-pub use has_components::HasComponents;
+pub use has_components::HasProvider;
 pub use is_provider::*;

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use cgp_async::{async_trait, Async, MaybeSend, MaybeStatic, MaybeSync};
 pub use cgp_component::{
-    CanUseComponent, DelegateComponent, HasComponents, IsProviderFor, UseFields, WithContext,
+    CanUseComponent, DelegateComponent, HasProvider, IsProviderFor, UseFields, WithContext,
     WithProvider,
 };
 pub use cgp_component_macro::{

--- a/crates/cgp-error/src/traits/can_raise_error.rs
+++ b/crates/cgp-error/src/traits/can_raise_error.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasComponents, IsProviderFor, UseDelegate};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseDelegate};
 use cgp_component_macro::{cgp_component, cgp_provider};
 
 use crate::traits::has_error_type::HasErrorType;

--- a/crates/cgp-error/src/traits/can_wrap_error.rs
+++ b/crates/cgp-error/src/traits/can_wrap_error.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasComponents, IsProviderFor, UseDelegate};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseDelegate};
 use cgp_component_macro::{cgp_component, cgp_provider};
 
 use crate::traits::HasErrorType;

--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_component::{DelegateComponent, HasComponents, IsProviderFor, WithProvider};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, WithProvider};
 use cgp_component_macro::cgp_type;
 use cgp_type::{ProvideType, UseType};
 

--- a/crates/cgp-type/src/traits/has_type.rs
+++ b/crates/cgp-type/src/traits/has_type.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasComponents, IsProviderFor, UseContext, UseDelegate};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, UseDelegate};
 use cgp_component_macro::{cgp_component, cgp_provider};
 
 #[cgp_component {


### PR DESCRIPTION
This PR renames the `HasComponents` trait to `HasProvider`. This is to clarify the relationship between a consumer trait and a provider trait, and what it implies when the trait is implemented by a context.

The name `HasProvider` better reflects what is happening, which is that the CGP context delegates the implementation of all its consumer traits to the specified provider.

Before:

```rust
pub trait HasComponents {
    type Components;
}
```

```rust
pub trait HasProvider {
    type Provider;
}
```