### PR TITLE
Introduce `#[cgp::re_export_imports]` macro

### DIFF
--- a/crates/cgp-component-macro-lib/src/lib.rs
+++ b/crates/cgp-component-macro-lib/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod for_each_replace;
 pub(crate) mod getter_component;
 pub(crate) mod parse;
 pub(crate) mod preset;
+pub(crate) mod re_export_imports;
 pub(crate) mod type_component;
 
 #[cfg(test)]
@@ -29,4 +30,5 @@ pub use crate::derive_provider::{derive_new_provider, derive_provider};
 pub use crate::for_each_replace::{handle_for_each_replace, handle_replace};
 pub use crate::getter_component::derive::{derive_auto_getter_component, derive_getter_component};
 pub use crate::preset::define_preset;
+pub use crate::re_export_imports::derive_re_export_imports;
 pub use crate::type_component::derive::derive_type_component;

--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -1,0 +1,39 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::token::Pub;
+use syn::{parse2, parse_quote, Error, Item, ItemMod, Visibility};
+
+pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+    if !attrs.is_empty() {
+        return Err(Error::new_spanned(
+            attrs,
+            "#[re_export_imports] do not accept any attribute argument",
+        ));
+    }
+
+    let mut item_mod: ItemMod = parse2(body)?;
+
+    let mod_name = &item_mod.ident;
+
+    if let Some(content) = &mut item_mod.content {
+        for item in content.1.iter_mut() {
+            if let Item::Use(use_item) = item {
+                match &use_item.vis {
+                    Visibility::Public(_) => {}
+                    _ => {
+                        use_item.vis = Visibility::Public(Pub(Span::call_site()));
+                        use_item.attrs.push(parse_quote!( #[doc(hidden)] ));
+                    }
+                }
+            }
+        }
+    }
+
+    let out = quote! {
+        #item_mod
+
+        pub use #mod_name ::*;
+    };
+
+    Ok(out)
+}

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -71,6 +71,13 @@ pub fn cgp_context(attr: TokenStream, item: TokenStream) -> TokenStream {
         .into()
 }
 
+#[proc_macro_attribute]
+pub fn re_export_imports(attrs: TokenStream, body: TokenStream) -> TokenStream {
+    cgp_component_macro_lib::derive_re_export_imports(attrs.into(), body.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
 #[proc_macro]
 pub fn for_each_replace(body: TokenStream) -> TokenStream {
     cgp_component_macro_lib::handle_for_each_replace(body.into())

--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -3,4 +3,7 @@
 pub mod prelude;
 
 pub use cgp_async::{async_trait, Async};
-pub use {cgp_component as component, cgp_error as error, cgp_field as field, cgp_type as types};
+pub use {
+    cgp_component as component, cgp_component_macro as macros, cgp_error as error,
+    cgp_field as field, cgp_type as types,
+};

--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod prelude;
 
 pub use cgp_async::{async_trait, Async};
+pub use cgp_component_macro::re_export_imports;
 pub use {
     cgp_component as component, cgp_component_macro as macros, cgp_error as error,
     cgp_field as field, cgp_type as types,

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -5,7 +5,7 @@ pub use cgp_component::{
 };
 pub use cgp_component_macro::{
     cgp_auto_getter, cgp_component, cgp_context, cgp_getter, cgp_preset, cgp_provider, cgp_type,
-    delegate_components, for_each_replace, new_cgp_provider, replace_with,
+    delegate_components, for_each_replace, new_cgp_provider, re_export_imports, replace_with,
 };
 pub use cgp_error::{
     CanRaiseAsyncError, CanRaiseError, CanWrapAsyncError, CanWrapError, HasAsyncErrorType,

--- a/crates/cgp/src/lib.rs
+++ b/crates/cgp/src/lib.rs
@@ -1,4 +1,4 @@
 #![no_std]
 
-pub use cgp_core::prelude;
+pub use cgp_core::{prelude, re_export_imports};
 pub use {cgp_core as core, cgp_extra as extra};


### PR DESCRIPTION
Introduce a new `#[cgp::re_export_imports]` macro to be applied on a `mod` module, so that all `use` imports become `pub use` with `#[doc(hidden)]` applied to them.

This macro is mainly used to help with re-exporting component name types when defining presets using the `cgp_preset!` macro. It allows users to not have to manually add `pub use` on all component types that are wired in a preset. The `#[doc(hidden)]` attribute is applied, so that the re-exports are not shown in Rustdocs, or suggested by Rust Analyzer.

Given the following code:

```rust
#[cgp::re_export_imports]
mod preset {
    use foo::FooComponent;
    use bar::BarComponent;
}
```

would be expanded into:

```rust
mod preset {
    #[doc(hidden)]
    pub use foo::FooComponent;
    #[doc(hidden)]
    pub use bar::BarComponent;
}

pub use preset::*;
```