### PR TITLE
Re-export imports inside a `re_export` submodule

### DIFF
--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -12,13 +12,13 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
 
     let mut re_exports: Vec<ItemUse> = Vec::new();
 
-    let item_mod: ItemMod = parse2(body)?;
+    let mut item_mod: ItemMod = parse2(body)?;
 
     let mod_name = &item_mod.ident;
 
     let doc_hidden: Attribute = parse_quote! { #[doc(hidden)] };
 
-    if let Some(content) = &item_mod.content {
+    if let Some(content) = &mut item_mod.content {
         for item in content.1.iter() {
             if let Item::Use(use_item) = item {
                 let mut re_export = use_item.clone();
@@ -27,6 +27,10 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
                 re_exports.push(re_export);
             }
         }
+
+        content.1.push(parse2(quote! {
+            use super:: #export_mod_name ;
+        })?);
     }
 
     let mut mod_body = TokenStream::new();

--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -1,36 +1,48 @@
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use quote::{quote, TokenStreamExt};
 use syn::token::Pub;
-use syn::{parse2, parse_quote, Error, Item, ItemMod, Visibility};
+use syn::{parse2, parse_quote, Attribute, Ident, Item, ItemMod, ItemUse, Visibility};
 
 pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
-    if !attrs.is_empty() {
-        return Err(Error::new_spanned(
-            attrs,
-            "#[re_export_imports] do not accept any attribute argument",
-        ));
-    }
+    let export_mod_name: Ident = if !attrs.is_empty() {
+        parse2(attrs)?
+    } else {
+        Ident::new("re_exports", Span::call_site())
+    };
 
-    let mut item_mod: ItemMod = parse2(body)?;
+    let mut re_exports: Vec<ItemUse> = Vec::new();
+
+    let item_mod: ItemMod = parse2(body)?;
 
     let mod_name = &item_mod.ident;
 
-    if let Some(content) = &mut item_mod.content {
-        for item in content.1.iter_mut() {
+    let doc_hidden: Attribute = parse_quote! { #[doc(hidden)] };
+
+    if let Some(content) = &item_mod.content {
+        for item in content.1.iter() {
             if let Item::Use(use_item) = item {
-                match &use_item.vis {
-                    Visibility::Public(_) => {}
-                    _ => {
-                        use_item.vis = Visibility::Public(Pub(Span::call_site()));
-                        use_item.attrs.push(parse_quote!( #[doc(hidden)] ));
-                    }
-                }
+                let mut re_export = use_item.clone();
+                re_export.vis = Visibility::Public(Pub(Span::call_site()));
+                re_export.attrs.push(doc_hidden.clone());
+                re_exports.push(re_export);
             }
         }
     }
 
+    let mut mod_body = TokenStream::new();
+    mod_body.append_all(re_exports);
+
+    let export_mod: ItemMod = parse2(quote! {
+        #[doc(hidden)]
+        pub mod #export_mod_name {
+            #mod_body
+        }
+    })?;
+
     let out = quote! {
         #item_mod
+
+        #export_mod
 
         pub use #mod_name ::*;
     };


### PR DESCRIPTION
## Summary

This PR is an improvement over #70 to re-export all imports inside a `re_exports` submodule, instead of re-exporting them all in the original parent module.

A main issue with the previous PR is that when `pub use preset::*` is used, it overrides any `#[doc(hidden)]` attributes on the re-exports, and unhide them again. Furthermore, with all imports being overridden with `pub use`, it becomes challenging to find any unused imports for removal.

With the new approach, we keep the original imports private, and duplicate the import statements inside a `re_exports` submodule. With that, any unused imports will be revealed by the original import statements.

## Example

Given the following code:

```rust
#[cgp::re_export_imports]
mod preset {
    use foo::FooComponent;
    use bar::BarComponent;
}
```

would be expanded into:

```rust
mod preset {
    use foo::FooComponent;
    use bar::BarComponent;

    use super::re_exports;
}

#[doc(hidden)]
pub mod re_exports {
    #[doc(hidden)]
    pub use foo::FooComponent;
    #[doc(hidden)]
    pub use bar::BarComponent;
}

pub use preset::*;
```
