### PR TITLE
Expand `cgp_preset!` into a preset module

### DIFF
--- a/crates/cgp-component-macro-lib/src/delegate_components/delegates_to.rs
+++ b/crates/cgp-component-macro-lib/src/delegate_components/delegates_to.rs
@@ -30,6 +30,7 @@ pub fn define_delegates_to_trait(
     let trait_bounds = define_delegate_component_trait_bounds(target_type, delegate_entries);
 
     let item_trait = parse_quote! {
+        #[doc(hidden)]
         pub trait #trait_name #target_generics: #trait_bounds {}
     };
 

--- a/crates/cgp-component-macro-lib/src/preset/ast.rs
+++ b/crates/cgp-component-macro-lib/src/preset/ast.rs
@@ -1,30 +1,21 @@
 use syn::parse::{Parse, ParseStream};
-use syn::token::Lt;
-use syn::{Generics, Ident};
 
 use crate::delegate_components::ast::DelegateEntriesAst;
+use crate::parse::SimpleType;
 
 pub struct DefinePresetAst {
-    pub preset_ident: Ident,
-    pub preset_generics: Generics,
+    pub preset: SimpleType,
     pub delegate_entries: DelegateEntriesAst,
 }
 
 impl Parse for DefinePresetAst {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let preset_ident: Ident = input.parse()?;
-
-        let preset_generics = if input.peek(Lt) {
-            input.parse()?
-        } else {
-            Default::default()
-        };
+        let preset = input.parse()?;
 
         let delegate_entries: DelegateEntriesAst = input.parse()?;
 
         Ok(Self {
-            preset_ident,
-            preset_generics,
+            preset,
             delegate_entries,
         })
     }

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -107,6 +107,8 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         pub mod #preset_module_name {
             use super::*;
 
+            #[doc(hidden)]
+            #[doc(no_inline)]
             pub use super::super::re_exports;
 
             #mod_output

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -19,11 +19,11 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
     let preset_generics: Generics = syn::parse2(quote!( #preset_generic_args ))?;
 
-    let preset_struct_name = Ident::new("Preset", Span::call_site());
+    let provider_struct_name = Ident::new("Provider", Span::call_site());
 
-    let preset_type = {
+    let provider_type = {
         let type_generics = preset_generics.split_for_impl().1;
-        parse2(quote! { #preset_struct_name #type_generics })?
+        parse2(quote! { #provider_struct_name #type_generics })?
     };
 
     let preset_trait_name = Ident::new("IsPreset", Span::call_site());
@@ -34,7 +34,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
     let impl_delegate_items = {
         let namespaces_preset_type = parse2(quote! {
-            #preset_module_name :: #preset_type
+            #preset_module_name :: #provider_type
         })?;
 
         let items = impl_delegate_components(
@@ -51,15 +51,15 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
     let impl_is_preset_items = impl_components_is_preset(
         &preset_trait_name,
-        &preset_type,
+        &provider_type,
         &preset_generics,
         &ast.delegate_entries,
     );
 
-    let preset_struct = define_struct(&preset_struct_name, &preset_generics);
+    let provider_struct = define_struct(&provider_struct_name, &preset_generics);
 
     let mut mod_output = quote! {
-        #preset_struct
+        #provider_struct
 
         #preset_trait
     };
@@ -71,7 +71,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
         let (delegates_to_trait, delegates_to_impl) = define_delegates_to_trait(
             &delegates_to_trait_name,
-            &preset_type,
+            &provider_type,
             &preset_generics,
             &ast.delegate_entries,
         );

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -2,8 +2,8 @@ use alloc::format;
 use alloc::string::ToString;
 
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
-use syn::{parse_quote, Ident, ItemTrait};
+use quote::{quote, ToTokens};
+use syn::{parse_quote, Generics, Ident, ItemTrait, Type};
 
 use crate::delegate_components::define_struct::define_struct;
 use crate::delegate_components::delegates_to::define_delegates_to_trait;
@@ -16,12 +16,14 @@ use crate::preset::substitution_macro::define_substitution_macro;
 pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let ast: DefinePresetAst = syn::parse2(body)?;
 
-    let preset_ident = &ast.preset_ident;
+    let preset_ident = &ast.preset.name;
+    let preset_generic_args = &ast.preset.generics;
 
-    let preset_type = {
-        let type_generics = ast.preset_generics.split_for_impl().1;
-        parse_quote!( #preset_ident #type_generics )
-    };
+    let preset_type: Type = syn::parse2(quote! {
+        #preset_ident #preset_generic_args
+    })?;
+
+    let preset_generics: Generics = syn::parse2(quote!( #preset_generic_args ))?;
 
     let preset_trait_name = Ident::new(&format!("Is{}", preset_ident), preset_ident.span());
 
@@ -30,16 +32,16 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     };
 
     let impl_delegate_items =
-        impl_delegate_components(&preset_type, &ast.preset_generics, &ast.delegate_entries);
+        impl_delegate_components(&preset_type, &preset_generics, &ast.delegate_entries);
 
     let impl_is_reset_items = impl_components_is_preset(
         &preset_trait_name,
         &preset_type,
-        &ast.preset_generics,
+        &preset_generics,
         &ast.delegate_entries,
     );
 
-    let item_struct = define_struct(&ast.preset_ident, &ast.preset_generics);
+    let item_struct = define_struct(preset_ident, &preset_generics);
 
     let mut output = TokenStream::new();
 
@@ -56,12 +58,12 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     }
 
     {
-        let delegates_to_trait_name = format!("DelegatesTo{}", ast.preset_ident);
+        let delegates_to_trait_name = format!("DelegatesTo{}", preset_ident);
 
         let (delegates_to_trait, delegates_to_impl) = define_delegates_to_trait(
             &Ident::new(&delegates_to_trait_name, Span::call_site()),
             &preset_type,
-            &ast.preset_generics,
+            &preset_generics,
             &ast.delegate_entries,
         );
 
@@ -71,7 +73,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
     {
         let with_components_macro_name =
-            format!("with_{}", to_snake_case_str(&ast.preset_ident.to_string()));
+            format!("with_{}", to_snake_case_str(&preset_ident.to_string()));
 
         let with_components_macro = define_substitution_macro(
             &Ident::new(&with_components_macro_name, Span::call_site()),

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -1,14 +1,10 @@
-use alloc::format;
-use alloc::string::ToString;
-
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{parse_quote, Generics, Ident, ItemTrait};
+use syn::{parse2, parse_quote, Generics, Ident, ItemTrait};
 
 use crate::delegate_components::define_struct::define_struct;
 use crate::delegate_components::delegates_to::define_delegates_to_trait;
 use crate::delegate_components::impl_delegate::impl_delegate_components;
-use crate::derive_component::snake_case::to_snake_case_str;
 use crate::preset::ast::DefinePresetAst;
 use crate::preset::impl_is_preset::impl_components_is_preset;
 use crate::preset::substitution_macro::define_substitution_macro;
@@ -16,24 +12,35 @@ use crate::preset::substitution_macro::define_substitution_macro;
 pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let ast: DefinePresetAst = syn::parse2(body)?;
 
-    let preset_ident = &ast.preset.name;
+    let preset_module_name = &ast.preset.name;
+
     let preset_generic_args = &ast.preset.generics;
 
     let preset_generics: Generics = syn::parse2(quote!( #preset_generic_args ))?;
 
+    let preset_struct_name = Ident::new("Preset", Span::call_site());
+
     let preset_type = {
         let type_generics = preset_generics.split_for_impl().1;
-        parse_quote!( #preset_ident #type_generics )
+        parse2(quote! { #preset_struct_name #type_generics })?
     };
 
-    let preset_trait_name = Ident::new(&format!("Is{}", preset_ident), preset_ident.span());
+    let preset_trait_name = Ident::new("IsPreset", Span::call_site());
 
     let preset_trait: ItemTrait = parse_quote! {
         pub trait #preset_trait_name <Component> {}
     };
 
     let impl_delegate_items = {
-        let items = impl_delegate_components(&preset_type, &preset_generics, &ast.delegate_entries);
+        let namespaces_preset_type = parse2(quote! {
+            #preset_module_name :: #preset_type
+        })?;
+
+        let items = impl_delegate_components(
+            &namespaces_preset_type,
+            &preset_generics,
+            &ast.delegate_entries,
+        );
 
         let mut stream = TokenStream::new();
         stream.append_all(items);
@@ -48,19 +55,21 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         &ast.delegate_entries,
     );
 
-    let item_struct = define_struct(preset_ident, &preset_generics);
+    let preset_struct = define_struct(&preset_struct_name, &preset_generics);
 
     let mut mod_output = quote! {
+        #preset_struct
+
         #preset_trait
     };
 
     mod_output.append_all(impl_is_preset_items);
 
     {
-        let delegates_to_trait_name = format!("DelegatesTo{}", preset_ident);
+        let delegates_to_trait_name = Ident::new("DelegatesToPreset", Span::call_site());
 
         let (delegates_to_trait, delegates_to_impl) = define_delegates_to_trait(
-            &Ident::new(&delegates_to_trait_name, Span::call_site()),
+            &delegates_to_trait_name,
             &preset_type,
             &preset_generics,
             &ast.delegate_entries,
@@ -71,11 +80,10 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     }
 
     {
-        let with_components_macro_name =
-            format!("with_{}", to_snake_case_str(&preset_ident.to_string()));
+        let with_components_macro_name = Ident::new("with_components", Span::call_site());
 
         let with_components_macro = define_substitution_macro(
-            &Ident::new(&with_components_macro_name, Span::call_site()),
+            &with_components_macro_name,
             &ast.delegate_entries.all_components().to_token_stream(),
         );
 
@@ -83,17 +91,13 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     }
 
     let output = quote! {
-        #item_struct
-
-        #impl_delegate_items
-
-        mod preset {
+        pub mod #preset_module_name {
             use super::*;
 
             #mod_output
         }
 
-        pub use preset::*;
+        #impl_delegate_items
     };
 
     Ok(output)

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -108,8 +108,11 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
             use super::*;
 
             #[doc(hidden)]
-            #[doc(no_inline)]
-            pub use super::super::re_exports;
+            pub mod re_exports {
+                #[doc(hidden)]
+                #[doc(no_inline)]
+                pub use super::super::super::re_exports::*;
+            }
 
             #mod_output
         }

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -91,13 +91,18 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     }
 
     let output = quote! {
+        #impl_delegate_items
+
+        #[allow(non_snake_case)]
         pub mod #preset_module_name {
             use super::*;
 
+            mod re_exports {
+                pub use super::super::*;
+            }
+
             #mod_output
         }
-
-        #impl_delegate_items
     };
 
     Ok(output)

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::string::ToString;
 
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{parse_quote, Generics, Ident, ItemTrait};
 
 use crate::delegate_components::define_struct::define_struct;
@@ -35,7 +35,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let impl_delegate_items =
         impl_delegate_components(&preset_type, &preset_generics, &ast.delegate_entries);
 
-    let impl_is_reset_items = impl_components_is_preset(
+    let impl_is_preset_items = impl_components_is_preset(
         &preset_trait_name,
         &preset_type,
         &preset_generics,
@@ -44,19 +44,14 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
     let item_struct = define_struct(preset_ident, &preset_generics);
 
-    let mut output = TokenStream::new();
+    let mut mod_output = quote! {
+        #item_struct
 
-    output.extend(item_struct.to_token_stream());
+        #preset_trait
+    };
 
-    output.extend(preset_trait.to_token_stream());
-
-    for impl_item in impl_delegate_items {
-        output.extend(impl_item.to_token_stream());
-    }
-
-    for impl_item in impl_is_reset_items {
-        output.extend(impl_item.to_token_stream());
-    }
+    mod_output.append_all(impl_delegate_items);
+    mod_output.append_all(impl_is_preset_items);
 
     {
         let delegates_to_trait_name = format!("DelegatesTo{}", preset_ident);
@@ -68,8 +63,8 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
             &ast.delegate_entries,
         );
 
-        output.extend(delegates_to_trait.to_token_stream());
-        output.extend(delegates_to_impl.to_token_stream());
+        mod_output.extend(delegates_to_trait.to_token_stream());
+        mod_output.extend(delegates_to_impl.to_token_stream());
     }
 
     {
@@ -81,8 +76,16 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
             &ast.delegate_entries.all_components().to_token_stream(),
         );
 
-        output.extend(with_components_macro);
+        mod_output.extend(with_components_macro);
     }
+
+    let output = quote! {
+        mod preset {
+            #mod_output
+        }
+
+        pub use preset::*;
+    };
 
     Ok(output)
 }

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -29,6 +29,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let preset_trait_name = Ident::new("IsPreset", Span::call_site());
 
     let preset_trait: ItemTrait = parse_quote! {
+        #[doc(hidden)]
         pub trait #preset_trait_name <Component> {}
     };
 

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -5,6 +5,7 @@ use syn::{parse2, parse_quote, Generics, Ident, ItemTrait};
 use crate::delegate_components::define_struct::define_struct;
 use crate::delegate_components::delegates_to::define_delegates_to_trait;
 use crate::delegate_components::impl_delegate::impl_delegate_components;
+use crate::derive_component::snake_case::to_snake_case_str;
 use crate::preset::ast::DefinePresetAst;
 use crate::preset::impl_is_preset::impl_components_is_preset;
 use crate::preset::substitution_macro::define_substitution_macro;
@@ -80,7 +81,13 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     }
 
     {
-        let with_components_macro_name = Ident::new("with_components", Span::call_site());
+        let with_components_macro_name = Ident::new(
+            &format!(
+                "with_{}",
+                to_snake_case_str(&preset_module_name.to_string())
+            ),
+            Span::call_site(),
+        );
 
         let with_components_macro = define_substitution_macro(
             &with_components_macro_name,
@@ -88,6 +95,9 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         );
 
         mod_output.extend(with_components_macro);
+        mod_output.extend(quote! {
+            pub use #with_components_macro_name as with_components;
+        })
     }
 
     let output = quote! {

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -107,7 +107,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         pub mod #preset_module_name {
             use super::*;
 
-            mod re_exports {
+            pub mod re_exports {
                 pub use super::super::*;
             }
 

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -107,9 +107,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         pub mod #preset_module_name {
             use super::*;
 
-            pub mod re_exports {
-                pub use super::super::*;
-            }
+            pub use super::re_exports;
 
             #mod_output
         }

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -107,7 +107,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         pub mod #preset_module_name {
             use super::*;
 
-            pub use super::re_exports;
+            pub use super::super::re_exports;
 
             #mod_output
         }

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -81,6 +81,8 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
     let output = quote! {
         mod preset {
+            use super::*;
+
             #mod_output
         }
 

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -32,8 +32,14 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         pub trait #preset_trait_name <Component> {}
     };
 
-    let impl_delegate_items =
-        impl_delegate_components(&preset_type, &preset_generics, &ast.delegate_entries);
+    let impl_delegate_items = {
+        let items = impl_delegate_components(&preset_type, &preset_generics, &ast.delegate_entries);
+
+        let mut stream = TokenStream::new();
+        stream.append_all(items);
+
+        stream
+    };
 
     let impl_is_preset_items = impl_components_is_preset(
         &preset_trait_name,
@@ -45,12 +51,9 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let item_struct = define_struct(preset_ident, &preset_generics);
 
     let mut mod_output = quote! {
-        #item_struct
-
         #preset_trait
     };
 
-    mod_output.append_all(impl_delegate_items);
     mod_output.append_all(impl_is_preset_items);
 
     {
@@ -80,6 +83,10 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     }
 
     let output = quote! {
+        #item_struct
+
+        #impl_delegate_items
+
         mod preset {
             use super::*;
 

--- a/crates/cgp-component-macro-lib/src/preset/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/preset/define_preset.rs
@@ -3,7 +3,7 @@ use alloc::string::ToString;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{parse_quote, Generics, Ident, ItemTrait, Type};
+use syn::{parse_quote, Generics, Ident, ItemTrait};
 
 use crate::delegate_components::define_struct::define_struct;
 use crate::delegate_components::delegates_to::define_delegates_to_trait;
@@ -19,11 +19,12 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let preset_ident = &ast.preset.name;
     let preset_generic_args = &ast.preset.generics;
 
-    let preset_type: Type = syn::parse2(quote! {
-        #preset_ident #preset_generic_args
-    })?;
-
     let preset_generics: Generics = syn::parse2(quote!( #preset_generic_args ))?;
+
+    let preset_type = {
+        let type_generics = preset_generics.split_for_impl().1;
+        parse_quote!( #preset_ident #type_generics )
+    };
 
     let preset_trait_name = Ident::new(&format!("Is{}", preset_ident), preset_ident.span());
 

--- a/crates/cgp-component-macro-lib/src/preset/substitution_macro.rs
+++ b/crates/cgp-component-macro-lib/src/preset/substitution_macro.rs
@@ -13,7 +13,5 @@ pub fn define_substitution_macro(macro_name: &Ident, substitution: &TokenStream)
                 }
             };
         }
-
-        pub use #macro_name;
     }
 }

--- a/crates/cgp-component-macro-lib/src/preset/substitution_macro.rs
+++ b/crates/cgp-component-macro-lib/src/preset/substitution_macro.rs
@@ -5,6 +5,7 @@ use syn::Ident;
 pub fn define_substitution_macro(macro_name: &Ident, substitution: &TokenStream) -> TokenStream {
     quote! {
         #[macro_export]
+        #[doc(hidden)]
         macro_rules! #macro_name {
             ( $( $body:tt )* ) => {
                 replace_with! {

--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -38,8 +38,7 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
 
     let export_mod: ItemMod = parse2(quote! {
         #[doc(hidden)]
-        #[doc(no_inline)]
-        pub mod #export_mod_name {
+        mod #export_mod_name {
             #mod_body
         }
     })?;

--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -12,13 +12,13 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
 
     let mut re_exports: Vec<ItemUse> = Vec::new();
 
-    let mut item_mod: ItemMod = parse2(body)?;
+    let item_mod: ItemMod = parse2(body)?;
 
     let mod_name = &item_mod.ident;
 
     let doc_hidden: Attribute = parse_quote! { #[doc(hidden)] };
 
-    if let Some(content) = &mut item_mod.content {
+    if let Some(content) = &item_mod.content {
         for item in content.1.iter() {
             if let Item::Use(use_item) = item {
                 let mut re_export = use_item.clone();
@@ -27,11 +27,6 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
                 re_exports.push(re_export);
             }
         }
-
-        content.1.push(parse2(quote! {
-            #[doc(hidden)]
-            pub use super:: #export_mod_name ;
-        })?);
     }
 
     let mut mod_body = TokenStream::new();

--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -29,7 +29,8 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
         }
 
         content.1.push(parse2(quote! {
-            use super:: #export_mod_name ;
+            #[doc(hidden)]
+            pub use super:: #export_mod_name ;
         })?);
     }
 

--- a/crates/cgp-component-macro-lib/src/re_export_imports.rs
+++ b/crates/cgp-component-macro-lib/src/re_export_imports.rs
@@ -17,13 +17,17 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
     let mod_name = &item_mod.ident;
 
     let doc_hidden: Attribute = parse_quote! { #[doc(hidden)] };
+    let doc_no_inline: Attribute = parse_quote! { #[doc(no_inline)] };
 
     if let Some(content) = &item_mod.content {
         for item in content.1.iter() {
             if let Item::Use(use_item) = item {
                 let mut re_export = use_item.clone();
+
                 re_export.vis = Visibility::Public(Pub(Span::call_site()));
                 re_export.attrs.push(doc_hidden.clone());
+                re_export.attrs.push(doc_no_inline.clone());
+
                 re_exports.push(re_export);
             }
         }
@@ -34,6 +38,7 @@ pub fn derive_re_export_imports(attrs: TokenStream, body: TokenStream) -> syn::R
 
     let export_mod: ItemMod = parse2(quote! {
         #[doc(hidden)]
+        #[doc(no_inline)]
         pub mod #export_mod_name {
             #mod_body
         }

--- a/crates/cgp-component-macro-lib/src/tests/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/tests/define_preset.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
 use crate::define_preset;
-use crate::tests::helper::equal::equal_token_stream;
+use crate::tests::helper::equal::assert_equal_token_stream;
 
 #[test]
 fn test_basic_define_preset() {
@@ -82,7 +82,7 @@ fn test_basic_define_preset() {
         pub use with_foo_preset;
     };
 
-    assert!(equal_token_stream(&derived, &expected));
+    assert_equal_token_stream(&derived, &expected);
 }
 
 #[test]
@@ -275,5 +275,5 @@ fn test_define_preset_containing_generics() {
         pub use with_foo_preset;
     };
 
-    assert!(equal_token_stream(&derived, &expected));
+    assert_equal_token_stream(&derived, &expected);
 }

--- a/crates/cgp-component-macro-lib/src/tests/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/tests/define_preset.rs
@@ -101,178 +101,155 @@ fn test_define_preset_containing_generics() {
     .unwrap();
 
     let expected = quote! {
-        pub struct FooPreset<'a, FooParamA, FooParamB>(
-            pub ::core::marker::PhantomData<(&'a (), FooParamA, FooParamB)>,
-        );
-
-        pub trait IsFooPreset<Component> {}
-
         impl<'a, FooParamA, FooParamB: FooConstraint> DelegateComponent<BarComponentA>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         {
             type Delegate = BazComponentsA<FooParamA>;
         }
 
         impl<'a, FooParamA, FooParamB: FooConstraint, __Context__, __Params__>
             IsProviderFor<BarComponentA, __Context__, __Params__>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         where
             BazComponentsA<FooParamA>: IsProviderFor<BarComponentA, __Context__, __Params__>,
-        {}
+        {
+        }
 
         impl<'a, FooParamA, FooParamB: FooConstraint> DelegateComponent<BarComponentB<'a>>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         {
             type Delegate = BazComponentsB;
         }
 
         impl<'a, FooParamA, FooParamB: FooConstraint, __Context__, __Params__>
             IsProviderFor<BarComponentB<'a>, __Context__, __Params__>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         where
             BazComponentsB: IsProviderFor<BarComponentB<'a>, __Context__, __Params__>,
-        {}
+        {
+        }
 
         impl<'a, FooParamA, FooParamB: FooConstraint> DelegateComponent<BarComponentC<FooParamB>>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         {
             type Delegate = BazComponentsB;
         }
 
         impl<'a, FooParamA, FooParamB: FooConstraint, __Context__, __Params__>
             IsProviderFor<BarComponentC<FooParamB>, __Context__, __Params__>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         where
             BazComponentsB: IsProviderFor<BarComponentC<FooParamB>, __Context__, __Params__>,
-        {}
+        {
+        }
 
-        impl<
-            'a,
-            FooParamA,
-            FooParamB: FooConstraint,
-            BarParamA,
-        > DelegateComponent<BarComponentD<BarParamA, FooParamA>>
-            for FooPreset<'a, FooParamA, FooParamB>
+        impl<'a, FooParamA, FooParamB: FooConstraint, BarParamA>
+            DelegateComponent<BarComponentD<BarParamA, FooParamA>>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         {
             type Delegate = BazComponentsB;
         }
 
-        impl<
-            'a,
-            FooParamA,
-            FooParamB: FooConstraint,
-            BarParamA,
-            __Context__,
-            __Params__,
-        >
+        impl<'a, FooParamA, FooParamB: FooConstraint, BarParamA, __Context__, __Params__>
             IsProviderFor<BarComponentD<BarParamA, FooParamA>, __Context__, __Params__>
-            for FooPreset<'a, FooParamA, FooParamB>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         where
             BazComponentsB: IsProviderFor<BarComponentD<BarParamA, FooParamA>, __Context__, __Params__>,
-        {}
+        {
+        }
 
-        impl<
-            'a,
-            'b,
-            FooParamA,
-            FooParamB: FooConstraint,
-            BarParamB: BarConstraint,
-        > DelegateComponent<BarComponentE<'b, BarParamB, FooParamB>>
-            for FooPreset<'a, FooParamA, FooParamB>
+        impl<'a, 'b, FooParamA, FooParamB: FooConstraint, BarParamB: BarConstraint>
+            DelegateComponent<BarComponentE<'b, BarParamB, FooParamB>>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         {
             type Delegate = BazComponentsB;
         }
 
         impl<
-            'a,
-            'b,
-            FooParamA,
-            FooParamB: FooConstraint,
-            BarParamB: BarConstraint,
-            __Context__,
-            __Params__,
-        >
-            IsProviderFor<BarComponentE<'b, BarParamB, FooParamB>, __Context__, __Params__>
-            for FooPreset<'a, FooParamA, FooParamB>
+                'a,
+                'b,
+                FooParamA,
+                FooParamB: FooConstraint,
+                BarParamB: BarConstraint,
+                __Context__,
+                __Params__,
+            > IsProviderFor<BarComponentE<'b, BarParamB, FooParamB>, __Context__, __Params__>
+            for FooPreset::Provider<'a, FooParamA, FooParamB>
         where
-            BazComponentsB: IsProviderFor<BarComponentE<'b, BarParamB, FooParamB>, __Context__, __Params__>,
-        {}
-
-        impl<T> IsFooPreset<BarComponentA> for T {}
-        impl<T> IsFooPreset<BarComponentB<'a>> for T {}
-        impl<T> IsFooPreset<BarComponentC<FooParamB>> for T {}
-
-        impl<BarParamA, T> IsFooPreset<BarComponentD<BarParamA, FooParamA>> for T {}
-
-        impl<'b, BarParamB: BarConstraint, T> IsFooPreset<BarComponentE<'b, BarParamB, FooParamB>> for T {}
-
-        pub trait DelegatesToFooPreset<
-            'a,
-            FooParamA,
-            FooParamB: FooConstraint,
-        >: DelegateComponent<
-                BarComponentA,
-                Delegate = FooPreset<'a, FooParamA, FooParamB>,
-            > + DelegateComponent<
-                BarComponentB<'a>,
-                Delegate = FooPreset<'a, FooParamA, FooParamB>,
-            > + DelegateComponent<
-                BarComponentC<FooParamB>,
-                Delegate = FooPreset<'a, FooParamA, FooParamB>,
-            > + DelegateComponent<
-                BarComponentD<BarParamA, FooParamA>,
-                Delegate = FooPreset<'a, FooParamA, FooParamB>,
-            > + DelegateComponent<
-                BarComponentE<'b, BarParamB, FooParamB>,
-                Delegate = FooPreset<'a, FooParamA, FooParamB>,
-            > {}
-
-        impl<
-            'a,
-            FooParamA,
-            FooParamB: FooConstraint,
-            Components,
-        > DelegatesToFooPreset<'a, FooParamA, FooParamB> for Components
-        where
-            Components: DelegateComponent<
-                    BarComponentA,
-                    Delegate = FooPreset<'a, FooParamA, FooParamB>,
-                >
-                + DelegateComponent<
-                    BarComponentB<'a>,
-                    Delegate = FooPreset<'a, FooParamA, FooParamB>,
-                >
-                + DelegateComponent<
-                    BarComponentC<FooParamB>,
-                    Delegate = FooPreset<'a, FooParamA, FooParamB>,
-                >
-                + DelegateComponent<
-                    BarComponentD<BarParamA, FooParamA>,
-                    Delegate = FooPreset<'a, FooParamA, FooParamB>,
-                >
-                + DelegateComponent<
-                    BarComponentE<'b, BarParamB, FooParamB>,
-                    Delegate = FooPreset<'a, FooParamA, FooParamB>,
-                >,
-        {}
-
-        #[macro_export]
-        macro_rules! with_foo_preset {
-            ($($body:tt)*) => {
-                replace_with! {
-                    [
-                        BarComponentA,
-                        BarComponentB<'a>,
-                        BarComponentC<FooParamB>,
-                        <BarParamA> BarComponentD<BarParamA, FooParamA>,
-                        <'b, BarParamB: BarConstraint> BarComponentE<'b, BarParamB, FooParamB>
-                    ],
-                    $( $body )*
-                }
-            };
+            BazComponentsB:
+                IsProviderFor<BarComponentE<'b, BarParamB, FooParamB>, __Context__, __Params__>,
+        {
         }
 
-        pub use with_foo_preset;
+        #[allow(non_snake_case)]
+        pub mod FooPreset {
+            use super::*;
+
+            #[doc(hidden)]
+            pub mod re_exports {
+                #[doc(hidden)]
+                #[doc(no_inline)]
+                pub use super::super::super::re_exports::*;
+            }
+
+            pub struct Provider<'a, FooParamA, FooParamB>(
+                pub ::core::marker::PhantomData<(&'a (), FooParamA, FooParamB)>,
+            );
+
+            pub trait IsPreset<Component> {}
+
+            impl<T> IsPreset<BarComponentA> for T {}
+            impl<T> IsPreset<BarComponentB<'a>> for T {}
+            impl<T> IsPreset<BarComponentC<FooParamB>> for T {}
+            impl<BarParamA, T> IsPreset<BarComponentD<BarParamA, FooParamA>> for T {}
+            impl<'b, BarParamB: BarConstraint, T> IsPreset<BarComponentE<'b, BarParamB, FooParamB>> for T {}
+
+            pub trait DelegatesToPreset<'a, FooParamA, FooParamB: FooConstraint>:
+                DelegateComponent<BarComponentA, Delegate = Provider<'a, FooParamA, FooParamB>>
+                + DelegateComponent<BarComponentB<'a>, Delegate = Provider<'a, FooParamA, FooParamB>>
+                + DelegateComponent<
+                    BarComponentC<FooParamB>,
+                    Delegate = Provider<'a, FooParamA, FooParamB>,
+                > + DelegateComponent<
+                    BarComponentD<BarParamA, FooParamA>,
+                    Delegate = Provider<'a, FooParamA, FooParamB>,
+                > + DelegateComponent<
+                    BarComponentE<'b, BarParamB, FooParamB>,
+                    Delegate = Provider<'a, FooParamA, FooParamB>,
+                >
+            {
+            }
+
+            impl<'a, FooParamA, FooParamB: FooConstraint, Components>
+                DelegatesToPreset<'a, FooParamA, FooParamB> for Components
+            where
+                Components: DelegateComponent<BarComponentA, Delegate = Provider<'a, FooParamA, FooParamB>>
+                    + DelegateComponent<BarComponentB<'a>, Delegate = Provider<'a, FooParamA, FooParamB>>
+                    + DelegateComponent<
+                        BarComponentC<FooParamB>,
+                        Delegate = Provider<'a, FooParamA, FooParamB>,
+                    > + DelegateComponent<
+                        BarComponentD<BarParamA, FooParamA>,
+                        Delegate = Provider<'a, FooParamA, FooParamB>,
+                    > + DelegateComponent<
+                        BarComponentE<'b, BarParamB, FooParamB>,
+                        Delegate = Provider<'a, FooParamA, FooParamB>,
+                    >,
+            {
+            }
+
+            #[macro_export]
+            macro_rules! with_foo_preset {
+                ($($body:tt)*) => {
+                    replace_with! { [BarComponentA, BarComponentB < 'a >, BarComponentC <
+                    FooParamB >, < BarParamA > BarComponentD < BarParamA, FooParamA >, < 'b,
+                    BarParamB : BarConstraint > BarComponentE < 'b, BarParamB, FooParamB >],
+                    $($body)* }
+                };
+            }
+
+            pub use with_foo_preset as with_components;
+        }
     };
 
     assert_equal_token_stream(&derived, &expected);

--- a/crates/cgp-component-macro-lib/src/tests/define_preset.rs
+++ b/crates/cgp-component-macro-lib/src/tests/define_preset.rs
@@ -17,69 +17,70 @@ fn test_basic_define_preset() {
     .unwrap();
 
     let expected = quote! {
-        pub struct FooPreset;
-
-        pub trait IsFooPreset<Component> {}
-
-        impl DelegateComponent<BarAComponent> for FooPreset {
+        impl DelegateComponent<BarAComponent> for FooPreset::Provider {
             type Delegate = BazAComponents;
         }
-
-        impl<__Context__, __Params__> IsProviderFor<BarAComponent, __Context__, __Params__> for FooPreset
+        impl<__Context__, __Params__> IsProviderFor<BarAComponent, __Context__, __Params__>
+            for FooPreset::Provider
         where
             BazAComponents: IsProviderFor<BarAComponent, __Context__, __Params__>,
-        {}
-
-        impl DelegateComponent<BarBComponent> for FooPreset {
+        {
+        }
+        impl DelegateComponent<BarBComponent> for FooPreset::Provider {
             type Delegate = BazAComponents;
         }
-
-        impl<__Context__, __Params__> IsProviderFor<BarBComponent, __Context__, __Params__> for FooPreset
+        impl<__Context__, __Params__> IsProviderFor<BarBComponent, __Context__, __Params__>
+            for FooPreset::Provider
         where
             BazAComponents: IsProviderFor<BarBComponent, __Context__, __Params__>,
-        {}
-
-        impl DelegateComponent<BarCComponent> for FooPreset {
+        {
+        }
+        impl DelegateComponent<BarCComponent> for FooPreset::Provider {
             type Delegate = BazBComponents;
         }
-
-        impl<__Context__, __Params__> IsProviderFor<BarCComponent, __Context__, __Params__> for FooPreset
+        impl<__Context__, __Params__> IsProviderFor<BarCComponent, __Context__, __Params__>
+            for FooPreset::Provider
         where
             BazBComponents: IsProviderFor<BarCComponent, __Context__, __Params__>,
-        {}
-
-        impl<T> IsFooPreset<BarAComponent> for T {}
-
-        impl<T> IsFooPreset<BarBComponent> for T {}
-
-        impl<T> IsFooPreset<BarCComponent> for T {}
-
-        pub trait DelegatesToFooPreset: DelegateComponent<
-                BarAComponent,
-                Delegate = FooPreset,
-            > + DelegateComponent<
-                BarBComponent,
-                Delegate = FooPreset,
-            > + DelegateComponent<BarCComponent, Delegate = FooPreset> {}
-
-        impl<Components> DelegatesToFooPreset for Components
-        where
-            Components: DelegateComponent<BarAComponent, Delegate = FooPreset>
-                + DelegateComponent<BarBComponent, Delegate = FooPreset>
-                + DelegateComponent<BarCComponent, Delegate = FooPreset>,
-        {}
-
-        #[macro_export]
-        macro_rules! with_foo_preset {
-            ($($body:tt)*) => {
-                replace_with! {
-                    [ BarAComponent, BarBComponent, BarCComponent ],
-                    $( $body )*
-                }
-            };
+        {
         }
-
-        pub use with_foo_preset;
+        #[allow(non_snake_case)]
+        pub mod FooPreset {
+            use super::*;
+            #[doc(hidden)]
+            pub mod re_exports {
+                #[doc(hidden)]
+                #[doc(no_inline)]
+                pub use super::super::super::re_exports::*;
+            }
+            pub struct Provider;
+            #[doc(hidden)]
+            pub trait IsPreset<Component> {}
+            impl<T> IsPreset<BarAComponent> for T {}
+            impl<T> IsPreset<BarBComponent> for T {}
+            impl<T> IsPreset<BarCComponent> for T {}
+            #[doc(hidden)]
+            pub trait DelegatesToPreset:
+                DelegateComponent<BarAComponent, Delegate = Provider>
+                + DelegateComponent<BarBComponent, Delegate = Provider>
+                + DelegateComponent<BarCComponent, Delegate = Provider>
+            {
+            }
+            impl<Components> DelegatesToPreset for Components where
+                Components: DelegateComponent<BarAComponent, Delegate = Provider>
+                    + DelegateComponent<BarBComponent, Delegate = Provider>
+                    + DelegateComponent<BarCComponent, Delegate = Provider>
+            {
+            }
+            #[macro_export]
+            #[doc(hidden)]
+            macro_rules! with_foo_preset {
+                    ($($body:tt)*) => {
+                        replace_with! { [BarAComponent, BarBComponent, BarCComponent], $($body)* }
+                    };
+                }
+            pub use with_foo_preset as with_components;
+        }
     };
 
     assert_equal_token_stream(&derived, &expected);
@@ -196,6 +197,7 @@ fn test_define_preset_containing_generics() {
                 pub ::core::marker::PhantomData<(&'a (), FooParamA, FooParamB)>,
             );
 
+            #[doc(hidden)]
             pub trait IsPreset<Component> {}
 
             impl<T> IsPreset<BarComponentA> for T {}
@@ -204,6 +206,7 @@ fn test_define_preset_containing_generics() {
             impl<BarParamA, T> IsPreset<BarComponentD<BarParamA, FooParamA>> for T {}
             impl<'b, BarParamB: BarConstraint, T> IsPreset<BarComponentE<'b, BarParamB, FooParamB>> for T {}
 
+            #[doc(hidden)]
             pub trait DelegatesToPreset<'a, FooParamA, FooParamB: FooConstraint>:
                 DelegateComponent<BarComponentA, Delegate = Provider<'a, FooParamA, FooParamB>>
                 + DelegateComponent<BarComponentB<'a>, Delegate = Provider<'a, FooParamA, FooParamB>>
@@ -239,6 +242,7 @@ fn test_define_preset_containing_generics() {
             }
 
             #[macro_export]
+            #[doc(hidden)]
             macro_rules! with_foo_preset {
                 ($($body:tt)*) => {
                     replace_with! { [BarComponentA, BarComponentB < 'a >, BarComponentC <

--- a/crates/cgp-component-macro-lib/src/tests/derive_context.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_context.rs
@@ -76,16 +76,18 @@ fn test_derive_context_with_preset() {
 
         impl<__Name__> DelegateComponent<__Name__> for FooComponents
         where
-            Self: IsFooPreset<__Name__>,
+            Self: FooPreset::IsPreset<__Name__>,
         {
-            type Delegate = FooPreset<BaseComponents>;
+            type Delegate = FooPreset::Provider<BaseComponents>;
         }
 
         impl<__Name__, __Context__, __Params__> IsProviderFor<__Name__, __Context__, __Params__>
         for FooComponents
         where
-            Self: IsFooPreset<__Name__>,
-            FooPreset<BaseComponents>: IsProviderFor<__Name__, __Context__, __Params__>,
+            Self: FooPreset::IsPreset<__Name__>,
+            FooPreset::Provider<
+                BaseComponents,
+            >: IsProviderFor<__Name__, __Context__, __Params__>,
         {}
     };
 


### PR DESCRIPTION
## Summary

This PR performs some redesign on the unstable `cgp_preset!` macro to make the definition of presets slightly more ergonomic. The main changes is that instead of being a struct, the defined preset is now a Rust module that contains several CGP constructs related to the preset.

## Use with `#[cgp::re_export_imports]`

The `cgp_preset!` macro now requires the module to be wrapped around a `mod` with `#[cgp::re_export_imports]`, in order to help re-exporting all imported component constructs.

A preset is now defined in the form:

```rust
#[cgp::re_export_imports]
mod preset {
    use cgp::prelude::*;
    use foo::{FooComponent, FooProvider};
    use bar::{BarComponent, BarProvider};

    cgp_preset! {
        MyPreset {
            FooComponent: FooProvider,
            BarComponent: BarProvider,
        }
    }
}
```

which would be roughly expanded into:

```rust
mod preset {
    use cgp::prelude::*;
    use foo::{FooComponent, FooProvider};
    use bar::{BarComponent, BarProvider};

    mod MyPreset {
        use super::*;

        pub struct Provider;

        delegate_components! {
            Provider {
                FooComponent: FooProvider,
                BarComponent: BarProvider,
            }
        }

        pub trait IsPreset<Component> {}

        impl<T> IsPreset<FooComponent> for T {}
        impl<T> IsPreset<BarComponent> for T {}

        #[macro_export]
        macro_rules! with_my_preset {
            ($($body:tt)*) => {
                replace_with! { [FooComponent, BarComponent], $($body)* }
            };
        }

        pub use with_my_preset as with_components;

        pub mod re_exports {
            pub use super::super::super::re_exports::*;
        }
    }
}

mod re_exports {
    pub use cgp::prelude::*;
    pub use foo::{FooComponent, FooProvider};
    pub use bar::{BarComponent, BarProvider};
}

pub use preset::*;
```

## Changes

- The provider name format has been renamed from `MyPreset` to `MyPreset::Provider`.
- The component match trait has been renamed from `IsMyPreset` to `MyPreset::IsPreset`.
- The substitution macro has been renamed from `with_my_preset!` to `MyPreset::with_components!`.