### PR TITLE
Permanently enable provider supertrait

### DIFF
--- a/crates/cgp-component-macro-lib/Cargo.toml
+++ b/crates/cgp-component-macro-lib/Cargo.toml
@@ -13,7 +13,6 @@ description  = """
 
 [features]
 default = []
-provider-supertrait = []
 
 [dependencies]
 syn             = { version = "2.0.95", features = [ "full", "extra-traits" ] }

--- a/crates/cgp-component-macro-lib/src/derive_component/provider_impl.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/provider_impl.rs
@@ -12,7 +12,6 @@ use syn::{
 use crate::derive_component::delegate_fn::derive_delegated_fn_impl;
 use crate::derive_component::delegate_type::derive_delegate_type_impl;
 use crate::derive_component::generic_args::extract_generic_args;
-use crate::derive_provider::ENABLE_IS_PROVIDER_SUPERTRAIT;
 
 pub fn derive_provider_impl(
     context_type: &Ident,
@@ -41,11 +40,9 @@ pub fn derive_provider_impl(
                 DelegateComponent< #component_name < #component_params > >
             };
 
-            if ENABLE_IS_PROVIDER_SUPERTRAIT {
-                delegate_constraint.push(parse_quote!(
-                    IsProviderFor< #component_name < #component_params >, #context_type, ( #is_provider_params ) >
-                ))
-            }
+            delegate_constraint.push(parse_quote!(
+                IsProviderFor< #component_name < #component_params >, #context_type, ( #is_provider_params ) >
+            ));
 
             let provider_constraint: Punctuated<TypeParamBound, Plus> = parse_quote! {
                 #provider_name < #provider_generic_args >

--- a/crates/cgp-component-macro-lib/src/derive_component/provider_trait.rs
+++ b/crates/cgp-component-macro-lib/src/derive_component/provider_trait.rs
@@ -9,7 +9,6 @@ use crate::derive_component::replace_self_receiver::replace_self_receiver;
 use crate::derive_component::replace_self_type::{
     iter_parse_and_replace_self_type, parse_and_replace_self_type,
 };
-use crate::derive_provider::ENABLE_IS_PROVIDER_SUPERTRAIT;
 
 pub fn derive_provider_trait(
     component_name: &Ident,
@@ -50,15 +49,11 @@ pub fn derive_provider_trait(
             &local_assoc_types,
         )?;
 
-        if ENABLE_IS_PROVIDER_SUPERTRAIT {
-            let is_provider_params = extract_generic_args(&consumer_trait.generics.params);
+        let is_provider_params = extract_generic_args(&consumer_trait.generics.params);
 
-            provider_trait.supertraits = parse_quote!(
-                IsProviderFor< #component_name < #component_params >, #context_type, ( #is_provider_params ) >
-            );
-        } else {
-            provider_trait.supertraits.clear();
-        }
+        provider_trait.supertraits = parse_quote!(
+            IsProviderFor< #component_name < #component_params >, #context_type, ( #is_provider_params ) >
+        );
 
         if !context_constraints.is_empty() {
             match &mut provider_trait.generics.where_clause {

--- a/crates/cgp-component-macro-lib/src/derive_provider/flag.rs
+++ b/crates/cgp-component-macro-lib/src/derive_provider/flag.rs
@@ -1,5 +1,0 @@
-#[cfg(feature = "provider-supertrait")]
-pub const ENABLE_IS_PROVIDER_SUPERTRAIT: bool = true;
-
-#[cfg(not(feature = "provider-supertrait"))]
-pub const ENABLE_IS_PROVIDER_SUPERTRAIT: bool = false;

--- a/crates/cgp-component-macro-lib/src/derive_provider/mod.rs
+++ b/crates/cgp-component-macro-lib/src/derive_provider/mod.rs
@@ -1,7 +1,5 @@
 mod derive;
-mod flag;
 mod replace_constraint;
 
 pub use derive::*;
-pub use flag::*;
 pub use replace_constraint::*;

--- a/crates/cgp-component-macro-lib/src/tests/derive_component.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_component.rs
@@ -21,7 +21,6 @@ fn test_basic_derive_component() {
     .unwrap();
 }
 
-#[cfg(feature = "provider-supertrait")]
 #[test]
 fn test_derive_component_with_const_generic() {
     let derived = derive_component(
@@ -69,67 +68,6 @@ fn test_derive_component_with_const_generic() {
         impl<Component, Context, const BAR: usize> FooProvider<Context, BAR> for Component
         where
             Component: DelegateComponent<FooComponent> + IsProviderFor<FooComponent, Context, (BAR)>,
-            Component::Delegate: FooProvider<Context, BAR>,
-        {
-            type Foo = <Component::Delegate as FooProvider<Context, BAR>>::Foo;
-
-            fn foo(context: &Context) -> Self::Foo {
-                Component::Delegate::foo(context)
-            }
-        }
-    };
-
-    assert_equal_token_stream(&derived, &expected);
-}
-
-#[cfg(not(feature = "provider-supertrait"))]
-#[test]
-fn test_derive_component_with_const_generic() {
-    let derived = derive_component(
-        quote! {
-            name: FooComponent,
-            provider: FooProvider,
-        },
-        quote! {
-            pub trait HasFoo<const BAR: usize> {
-                type Foo;
-
-                fn foo(&self) -> Self::Foo;
-            }
-        },
-    )
-    .unwrap();
-
-    let expected = quote! {
-        pub struct FooComponent;
-
-        pub trait HasFoo<const BAR: usize> {
-            type Foo;
-
-            fn foo(&self) -> Self::Foo;
-        }
-
-        pub trait FooProvider<Context, const BAR: usize> {
-            type Foo;
-
-            fn foo(context: &Context) -> Self::Foo;
-        }
-
-        impl<Context, const BAR: usize> HasFoo<BAR> for Context
-        where
-            Context: HasProvider,
-            Context::Provider: FooProvider<Context, BAR>,
-        {
-            type Foo = <Context::Provider as FooProvider<Context, BAR>>::Foo;
-
-            fn foo(&self) -> Self::Foo {
-                Context::Provider::foo(self)
-            }
-        }
-
-        impl<Component, Context, const BAR: usize> FooProvider<Context, BAR> for Component
-        where
-            Component: DelegateComponent<FooComponent>,
             Component::Delegate: FooProvider<Context, BAR>,
         {
             type Foo = <Component::Delegate as FooProvider<Context, BAR>>::Foo;

--- a/crates/cgp-component-macro/Cargo.toml
+++ b/crates/cgp-component-macro/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 
 [features]
 default = []
-provider-supertrait = [ "cgp-component-macro-lib/provider-supertrait" ]
 
 [dependencies]
 syn                     = { version = "2.0.95", features = [ "full", "extra-traits" ] }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -14,7 +14,6 @@ description  = """
 [features]
 default             = [ "full" ]
 full                = [ "cgp-async/full" ]
-provider-supertrait = [ "cgp-component-macro/provider-supertrait" ]
 
 [dependencies]
 cgp-async           = { version = "0.3.0", default-features = false }

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -14,7 +14,6 @@ description  = """
 [features]
 default             = [ "full" ]
 full                = [ "cgp-core/full", "cgp-extra/full" ]
-provider-supertrait = [ "cgp-core/provider-supertrait" ]
 
 [dependencies]
 cgp-async      = { version = "0.3.0", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81"
+channel = "1.85"
 profile = "default"


### PR DESCRIPTION
## Summary

This PR permanently enables the `provider-supertrait` feature and remove the feature flag. With this, the `IsProviderFor` trait introduced in https://github.com/contextgeneric/cgp/pull/63 is always included as a supertrait of provider traits derived from `#[cgp_component]`.

Moving onwards, this would require `#[cgp_provider]` to be used on all provider implementations to derive the `IsProviderFor` implementation for the providers. The main advantage introduced is that Rust now produces much more informative error messages, which allows the user to properly identify the root cause of why certain CGP trait is not implemented.