### PR TITLE
Rename `#[new_cgp_provider]` to `#[cgp_new_provider]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "cgp"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-async"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-async-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -36,11 +36,11 @@ dependencies = [
 
 [[package]]
 name = "cgp-component"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "cgp-component-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-component-macro-lib",
  "syn",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-component-macro-lib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-error"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-anyhow"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cgp-core",
@@ -90,14 +90,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-extra"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-error-eyre"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-core",
  "eyre",
@@ -105,14 +105,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-std"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-extra"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-error-extra",
  "cgp-inner",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-field"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-field-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-field-macro-lib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-inner"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-run"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -167,21 +167,21 @@ dependencies = [
 
 [[package]]
 name = "cgp-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-sync"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-async-macro",
 ]
 
 [[package]]
 name = "cgp-type"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",

--- a/crates/cgp-async-macro/Cargo.toml
+++ b/crates/cgp-async-macro/Cargo.toml
@@ -5,7 +5,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.3.0"
+version      = "0.4.0"
 keywords     = { workspace = true }
 description  = """
     Context-generic programming async macros

--- a/crates/cgp-async/Cargo.toml
+++ b/crates/cgp-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-async"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -25,5 +25,5 @@ sync = [ "async" ]
 static = [ "async" ]
 
 [dependencies]
-cgp-async-macro = { version = "0.3.0" }
-cgp-sync        = { version = "0.3.0" }
+cgp-async-macro = { version = "0.4.0" }
+cgp-sync        = { version = "0.4.0" }

--- a/crates/cgp-component-macro-lib/Cargo.toml
+++ b/crates/cgp-component-macro-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component-macro-lib"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-component-macro/Cargo.toml
+++ b/crates/cgp-component-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component-macro"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -19,4 +19,4 @@ default = []
 
 [dependencies]
 syn                     = { version = "2.0.95", features = [ "full", "extra-traits" ] }
-cgp-component-macro-lib = { version = "0.3.0" }
+cgp-component-macro-lib = { version = "0.4.0" }

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -23,7 +23,7 @@ pub fn cgp_provider(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn new_cgp_provider(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn cgp_new_provider(attr: TokenStream, item: TokenStream) -> TokenStream {
     cgp_component_macro_lib::derive_new_provider(attr.into(), item.into())
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()

--- a/crates/cgp-component/Cargo.toml
+++ b/crates/cgp-component/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-core"
-version      = "0.3.1"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -16,10 +16,10 @@ default             = [ "full" ]
 full                = [ "cgp-async/full" ]
 
 [dependencies]
-cgp-async           = { version = "0.3.0", default-features = false }
-cgp-component       = { version = "0.3.0" }
-cgp-component-macro = { version = "0.3.0" }
-cgp-type            = { version = "0.3.0" }
-cgp-error           = { version = "0.3.1" }
-cgp-field           = { version = "0.3.0" }
-cgp-field-macro     = { version = "0.3.0" }
+cgp-async           = { version = "0.4.0", default-features = false }
+cgp-component       = { version = "0.4.0" }
+cgp-component-macro = { version = "0.4.0" }
+cgp-type            = { version = "0.4.0" }
+cgp-error           = { version = "0.4.0" }
+cgp-field           = { version = "0.4.0" }
+cgp-field-macro     = { version = "0.4.0" }

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -4,8 +4,8 @@ pub use cgp_component::{
     WithProvider,
 };
 pub use cgp_component_macro::{
-    cgp_auto_getter, cgp_component, cgp_context, cgp_getter, cgp_preset, cgp_provider, cgp_type,
-    delegate_components, for_each_replace, new_cgp_provider, re_export_imports, replace_with,
+    cgp_auto_getter, cgp_component, cgp_context, cgp_getter, cgp_new_provider, cgp_preset,
+    cgp_provider, cgp_type, delegate_components, for_each_replace, re_export_imports, replace_with,
 };
 pub use cgp_error::{
     CanRaiseAsyncError, CanRaiseError, CanWrapAsyncError, CanWrapError, HasAsyncErrorType,

--- a/crates/cgp-error-anyhow/Cargo.toml
+++ b/crates/cgp-error-anyhow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-anyhow"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.3.0", default-features = false }
+cgp-core    = { version = "0.4.0", default-features = false }
 anyhow      = { version = "1.0.95", default-features = false }

--- a/crates/cgp-error-extra/Cargo.toml
+++ b/crates/cgp-error-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-extra"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -16,4 +16,4 @@ default = [ "alloc" ]
 alloc = []
 
 [dependencies]
-cgp-core    = { version = "0.3.0", default-features = false }
+cgp-core    = { version = "0.4.0", default-features = false }

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-eyre"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.3.0", default-features = false }
+cgp-core    = { version = "0.4.0", default-features = false }
 eyre        = { version = "0.6.12", default-features = false }

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-std"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.3.0", default-features = false }
+cgp-core    = { version = "0.4.0", default-features = false }

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error"
-version      = "0.3.1"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,7 +12,7 @@ description  = """
 """
 
 [dependencies]
-cgp-async           = { version = "0.3.0", default-features = false }
-cgp-component       = { version = "0.3.0" }
-cgp-component-macro = { version = "0.3.0" }
-cgp-type            = { version = "0.3.0" }
+cgp-async           = { version = "0.4.0", default-features = false }
+cgp-component       = { version = "0.4.0" }
+cgp-component-macro = { version = "0.4.0" }
+cgp-type            = { version = "0.4.0" }

--- a/crates/cgp-extra/Cargo.toml
+++ b/crates/cgp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-extra"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -15,7 +15,7 @@ default = [ "full" ]
 full = [ "cgp-error-extra/alloc" ]
 
 [dependencies]
-cgp-error-extra = { version = "0.3.0", default-features = false }
-cgp-inner       = { version = "0.3.0" }
-cgp-run         = { version = "0.3.0" }
-cgp-runtime     = { version = "0.3.0" }
+cgp-error-extra = { version = "0.4.0", default-features = false }
+cgp-inner       = { version = "0.4.0" }
+cgp-run         = { version = "0.4.0" }
+cgp-runtime     = { version = "0.4.0" }

--- a/crates/cgp-field-macro-lib/Cargo.toml
+++ b/crates/cgp-field-macro-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field-macro-lib"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-field-macro/Cargo.toml
+++ b/crates/cgp-field-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field-macro"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -15,5 +15,5 @@ description  = """
 proc-macro = true
 
 [dependencies]
-cgp-field-macro-lib = { version = "0.3.0" }
+cgp-field-macro-lib = { version = "0.4.0" }
 proc-macro2         = "1.0.92"

--- a/crates/cgp-field/Cargo.toml
+++ b/crates/cgp-field/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,6 +12,6 @@ description  = """
 """
 
 [dependencies]
-cgp-component       = { version = "0.3.0" }
-cgp-component-macro = { version = "0.3.0" }
-cgp-type            = { version = "0.3.0" }
+cgp-component       = { version = "0.4.0" }
+cgp-component-macro = { version = "0.4.0" }
+cgp-type            = { version = "0.4.0" }

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-inner"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-component       = { version = "0.3.0" }
-cgp-component-macro = { version = "0.3.0" }
+cgp-component       = { version = "0.4.0" }
+cgp-component-macro = { version = "0.4.0" }

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-run"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,7 +12,7 @@ description  = """
 """
 
 [dependencies]
-cgp-async           = { version = "0.3.0", default-features = false }
-cgp-error           = { version = "0.3.0" }
-cgp-component       = { version = "0.3.0" }
-cgp-component-macro = { version = "0.3.0" }
+cgp-async           = { version = "0.4.0", default-features = false }
+cgp-error           = { version = "0.4.0" }
+cgp-component       = { version = "0.4.0" }
+cgp-component-macro = { version = "0.4.0" }

--- a/crates/cgp-runtime/Cargo.toml
+++ b/crates/cgp-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-runtime"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-core    = { version = "0.3.0" }
+cgp-core    = { version = "0.4.0" }

--- a/crates/cgp-sync/Cargo.toml
+++ b/crates/cgp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-sync"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,4 +12,4 @@ description  = """
 """
 
 [dependencies]
-cgp-async-macro = { version = "0.3.0" }
+cgp-async-macro = { version = "0.4.0" }

--- a/crates/cgp-type/Cargo.toml
+++ b/crates/cgp-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-type"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -12,5 +12,5 @@ description  = """
 """
 
 [dependencies]
-cgp-component       = { version = "0.3.0" }
-cgp-component-macro = { version = "0.3.0" }
+cgp-component       = { version = "0.4.0" }
+cgp-component-macro = { version = "0.4.0" }

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp"
-version      = "0.3.1"
+version      = "0.4.0"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
@@ -16,6 +16,6 @@ default             = [ "full" ]
 full                = [ "cgp-core/full", "cgp-extra/full" ]
 
 [dependencies]
-cgp-async      = { version = "0.3.0", default-features = false }
-cgp-core       = { version = "0.3.1", default-features = false }
-cgp-extra      = { version = "0.3.0", default-features = false }
+cgp-async      = { version = "0.4.0", default-features = false }
+cgp-core       = { version = "0.4.0", default-features = false }
+cgp-extra      = { version = "0.4.0", default-features = false }


### PR DESCRIPTION
This PR renames the `#[new_cgp_provider]` macro to `#[cgp_new_provider]`, to make it more consistent with the name of the other CGP macros.