### PR TITLE
Fix `#[cgp_getter]` macro when the getter trait contains generic parameters

### DIFF
--- a/crates/cgp-component-macro-lib/src/getter_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/derive.rs
@@ -20,7 +20,8 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
 
     let fields = parse_getter_fields(&spec.context_type, &consumer_trait)?;
 
-    let use_fields_impl = derive_use_fields_impl(&spec, &consumer_trait, &fields);
+    let use_fields_impl =
+        derive_use_fields_impl(&spec, &derived_component.provider_trait, &fields)?;
 
     let component_name_type: Type = {
         let component_name = &spec.component_name;
@@ -42,12 +43,8 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
     };
 
     if let Some([field]) = m_field {
-        let use_field_impl = derive_use_field_impl(
-            &spec,
-            &consumer_trait,
-            &derived_component.provider_trait,
-            &field,
-        )?;
+        let use_field_impl =
+            derive_use_field_impl(&spec, &derived_component.provider_trait, &field)?;
         let is_provider_use_field_impl =
             derive_is_provider_for(&component_name_type, &use_field_impl)?;
 

--- a/crates/cgp-component-macro-lib/src/getter_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/derive.rs
@@ -42,7 +42,12 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
     };
 
     if let Some([field]) = m_field {
-        let use_field_impl = derive_use_field_impl(&spec, &consumer_trait, &field);
+        let use_field_impl = derive_use_field_impl(
+            &spec,
+            &consumer_trait,
+            &derived_component.provider_trait,
+            &field,
+        )?;
         let is_provider_use_field_impl =
             derive_is_provider_for(&component_name_type, &use_field_impl)?;
 

--- a/crates/cgp-component-macro-lib/src/getter_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/derive.rs
@@ -48,7 +48,8 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
         let is_provider_use_field_impl =
             derive_is_provider_for(&component_name_type, &use_field_impl)?;
 
-        let use_provider_impl = derive_with_provider_impl(&spec, &consumer_trait, &field);
+        let use_provider_impl =
+            derive_with_provider_impl(&spec, &derived_component.provider_trait, &field)?;
         let is_provider_use_provider_impl =
             derive_is_provider_for(&component_name_type, &use_provider_impl)?;
 

--- a/crates/cgp-component-macro-lib/src/getter_component/derive.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/derive.rs
@@ -29,7 +29,7 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
     };
 
     let is_provider_use_fields_impl =
-        derive_is_provider_for(&parse_quote!(#component_name_type), &use_fields_impl)?;
+        derive_is_provider_for(&component_name_type, &use_fields_impl)?;
 
     let m_field: Option<[GetterField; 1]> = fields.try_into().ok();
 
@@ -44,11 +44,11 @@ pub fn derive_getter_component(attr: TokenStream, body: TokenStream) -> syn::Res
     if let Some([field]) = m_field {
         let use_field_impl = derive_use_field_impl(&spec, &consumer_trait, &field);
         let is_provider_use_field_impl =
-            derive_is_provider_for(&parse_quote!(#component_name_type), &use_field_impl)?;
+            derive_is_provider_for(&component_name_type, &use_field_impl)?;
 
         let use_provider_impl = derive_with_provider_impl(&spec, &consumer_trait, &field);
         let is_provider_use_provider_impl =
-            derive_is_provider_for(&parse_quote!(#component_name_type), &use_provider_impl)?;
+            derive_is_provider_for(&component_name_type, &use_provider_impl)?;
 
         derived.extend(quote! {
             #use_field_impl

--- a/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
@@ -8,7 +8,6 @@ use crate::getter_component::getter_field::GetterField;
 
 pub fn derive_use_field_impl(
     spec: &ComponentSpec,
-    consumer_trait: &ItemTrait,
     provider_trait: &ItemTrait,
     field: &GetterField,
 ) -> syn::Result<ItemImpl> {

--- a/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
@@ -1,5 +1,7 @@
-use quote::quote;
-use syn::{parse_quote, ItemImpl, ItemTrait};
+use quote::{quote, ToTokens};
+use syn::punctuated::Punctuated;
+use syn::token::Plus;
+use syn::{parse2, parse_quote, Generics, ItemImpl, ItemTrait, TypeParamBound};
 
 use crate::derive_component::component_spec::ComponentSpec;
 use crate::getter_component::getter_field::GetterField;
@@ -7,20 +9,22 @@ use crate::getter_component::getter_field::GetterField;
 pub fn derive_use_field_impl(
     spec: &ComponentSpec,
     consumer_trait: &ItemTrait,
+    provider_trait: &ItemTrait,
     field: &GetterField,
-) -> ItemImpl {
+) -> syn::Result<ItemImpl> {
     let context_type = &spec.context_type;
-    let provider_name = &spec.provider_name;
+    let provider_name = &provider_trait.ident;
 
-    // FIXME: replace `Self` with `Context` inside super trait bound
-    let mut constraints = consumer_trait.supertraits.clone();
+    let mut field_constraints: Punctuated<TypeParamBound, Plus> = Punctuated::default();
 
     let field_name = &field.field_name;
     let provider_type = &field.provider_type;
 
+    let tag_type = quote! { __Tag__ };
+
     let method = if field.field_mut.is_none() {
-        constraints.push(parse_quote! {
-            HasField< Tag, Value = #provider_type >
+        field_constraints.push(parse_quote! {
+            HasField< #tag_type, Value = #provider_type >
         });
 
         quote! {
@@ -29,8 +33,8 @@ pub fn derive_use_field_impl(
             }
         }
     } else {
-        constraints.push(parse_quote! {
-            HasFieldMut< Tag, Value = #provider_type >
+        field_constraints.push(parse_quote! {
+            HasFieldMut< #tag_type, Value = #provider_type >
         });
 
         quote! {
@@ -40,14 +44,28 @@ pub fn derive_use_field_impl(
         }
     };
 
+    let mut provider_generics = provider_trait.generics.clone();
+
+    let mut where_clause = provider_generics.make_where_clause().clone();
+    where_clause
+        .predicates
+        .push(parse2(quote! { #context_type: #field_constraints })?);
+
+    let (impl_generics, type_generics, _) = provider_generics.split_for_impl();
+
+    let impl_generics = {
+        let mut generics: Generics = parse2(impl_generics.to_token_stream())?;
+        generics.params.push(parse2(tag_type.clone())?);
+        generics
+    };
+
     let use_field_impl: ItemImpl = parse_quote! {
-        impl< #context_type, Tag > #provider_name < #context_type > for UseField<Tag>
-        where
-            #context_type: #constraints
+        impl #impl_generics #provider_name #type_generics for UseField< #tag_type >
+        #where_clause
         {
             #method
         }
     };
 
-    use_field_impl
+    Ok(use_field_impl)
 }

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
 use crate::derive_getter_component;
-use crate::tests::helper::format::format_token_stream;
+use crate::tests::helper::equal::assert_equal_token_stream;
 
 #[test]
 fn test_derive_getter_basic() {
@@ -17,7 +17,107 @@ fn test_derive_getter_basic() {
     )
     .unwrap();
 
-    println!("derived: {}", format_token_stream(&derived));
+    let expected = quote! {
+        pub struct NameGetterComponent;
+
+        pub trait HasName: HasNameType {
+            fn name(&self) -> &Self::Name;
+        }
+
+        pub trait NameGetter<Context>: IsProviderFor<NameGetterComponent, Context, ()>
+        where
+            Context: HasNameType,
+        {
+            fn name(context: &Context) -> &Context::Name;
+        }
+
+        impl<Context> HasName for Context
+        where
+            Context: HasNameType,
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context>,
+        {
+            fn name(&self) -> &Self::Name {
+                Context::Provider::name(self)
+            }
+        }
+
+        impl<Component, Context> NameGetter<Context> for Component
+        where
+            Context: HasNameType,
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, ()>,
+            Component::Delegate: NameGetter<Context>,
+        {
+            fn name(context: &Context) -> &Context::Name {
+                Component::Delegate::name(context)
+            }
+        }
+
+        impl<Context> NameGetter<Context> for UseFields
+        where
+            Context: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Context::Name,
+            >,
+        {
+            fn name(context: &Context) -> &Context::Name {
+                context.get_field(
+                    ::core::marker::PhantomData::<
+                        Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                    >,
+                )
+            }
+        }
+
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseFields
+        where
+            Context: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Context::Name,
+            >,
+        {
+        }
+
+        impl<Context, __Tag__> NameGetter<Context> for UseField<__Tag__>
+        where
+            Context: HasNameType,
+            Context: HasField<__Tag__, Value = Context::Name>,
+        {
+            fn name(context: &Context) -> &Context::Name {
+                context.get_field(::core::marker::PhantomData)
+            }
+        }
+
+        impl<Context, __Tag__> IsProviderFor<NameGetterComponent, Context, ()> for UseField<__Tag__>
+        where
+            Context: HasNameType,
+            Context: HasField<__Tag__, Value = Context::Name>,
+        {
+        }
+
+        impl<Context, __Provider__> NameGetter<Context> for WithProvider<__Provider__>
+        where
+            Context: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = Context::Name>,
+        {
+            fn name(context: &Context) -> &Context::Name {
+                __Provider__::get_field(context, ::core::marker::PhantomData)
+            }
+        }
+
+        impl<Context, __Provider__> IsProviderFor<NameGetterComponent, Context, ()>
+            for WithProvider<__Provider__>
+        where
+            Context: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = Context::Name>,
+        {
+        }
+    };
+
+    assert_equal_token_stream(&derived, &expected);
 }
 
 #[test]
@@ -37,5 +137,108 @@ fn test_derive_getter_with_generics() {
     )
     .unwrap();
 
-    println!("derived: {}", format_token_stream(&derived));
+    let expected = quote! {
+        pub struct NameGetterComponent;
+
+        pub trait HasName<App>
+        where
+            App: HasNameType,
+        {
+            fn name(&self) -> &App::Name;
+        }
+
+        pub trait NameGetter<Context, App>: IsProviderFor<NameGetterComponent, Context, (App)>
+        where
+            App: HasNameType,
+        {
+            fn name(context: &Context) -> &App::Name;
+        }
+
+        impl<Context, App> HasName<App> for Context
+        where
+            App: HasNameType,
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context, App>,
+        {
+            fn name(&self) -> &App::Name {
+                Context::Provider::name(self)
+            }
+        }
+
+        impl<Component, Context, App> NameGetter<Context, App> for Component
+        where
+            App: HasNameType,
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, (App)>,
+            Component::Delegate: NameGetter<Context, App>,
+        {
+            fn name(context: &Context) -> &App::Name {
+                Component::Delegate::name(context)
+            }
+        }
+
+        impl<Context, App> NameGetter<Context, App> for UseFields
+        where
+            App: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = App::Name,
+            >,
+        {
+            fn name(context: &Context) -> &App::Name {
+                context.get_field(
+                    ::core::marker::PhantomData::<
+                        Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                    >,
+                )
+            }
+        }
+
+        impl<Context, App> IsProviderFor<NameGetterComponent, Context, (App)> for UseFields
+        where
+            App: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = App::Name,
+            >,
+        {
+        }
+
+        impl<Context, App, __Tag__> NameGetter<Context, App> for UseField<__Tag__>
+        where
+            App: HasNameType,
+            Context: HasField<__Tag__, Value = App::Name>,
+        {
+            fn name(context: &Context) -> &App::Name {
+                context.get_field(::core::marker::PhantomData)
+            }
+        }
+
+        impl<Context, App, __Tag__> IsProviderFor<NameGetterComponent, Context, (App)> for UseField<__Tag__>
+        where
+            App: HasNameType,
+            Context: HasField<__Tag__, Value = App::Name>,
+        {
+        }
+
+        impl<Context, App, __Provider__> NameGetter<Context, App> for WithProvider<__Provider__>
+        where
+            App: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = App::Name>,
+        {
+            fn name(context: &Context) -> &App::Name {
+                __Provider__::get_field(context, ::core::marker::PhantomData)
+            }
+        }
+
+        impl<Context, App, __Provider__> IsProviderFor<NameGetterComponent, Context, (App)>
+            for WithProvider<__Provider__>
+        where
+            App: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = App::Name>,
+        {
+        }
+    };
+
+    assert_equal_token_stream(&derived, &expected);
 }

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -1,0 +1,45 @@
+use quote::quote;
+
+use crate::derive_getter_component;
+use crate::tests::helper::format::format_token_stream;
+
+#[test]
+fn test_derive_getter_basic() {
+    let derived = derive_getter_component(
+        quote! {
+            provider: PersonFieldsGetter,
+        },
+        quote! {
+            pub trait HasPersonFields: HasNameType + HasAgeType {
+                fn name(&self) -> &Self::Name;
+
+                fn age(&self) -> &Self::Age;
+            }
+        },
+    )
+    .unwrap();
+
+    println!("derived: {}", format_token_stream(&derived));
+}
+
+#[test]
+fn test_derive_getter_with_generics() {
+    let derived = derive_getter_component(
+        quote! {
+            provider: PersonFieldsGetter,
+        },
+        quote! {
+            pub trait HasPersonFields<App>
+            where
+                App: HasNameType + HasAgeType,
+            {
+                fn name(&self) -> &App::Name;
+
+                fn age(&self) -> &App::Age;
+            }
+        },
+    )
+    .unwrap();
+
+    println!("derived: {}", format_token_stream(&derived));
+}

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -7,7 +7,7 @@ use crate::tests::helper::format::format_token_stream;
 fn test_derive_getter_basic() {
     let derived = derive_getter_component(
         quote! {
-            provider: PersonFieldsGetter,
+            provider: NameGetter,
         },
         quote! {
             pub trait HasName: HasNameType {
@@ -24,7 +24,7 @@ fn test_derive_getter_basic() {
 fn test_derive_getter_with_generics() {
     let derived = derive_getter_component(
         quote! {
-            provider: PersonFieldsGetter,
+            provider: NameGetter,
         },
         quote! {
             pub trait HasName<App>

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -10,10 +10,8 @@ fn test_derive_getter_basic() {
             provider: PersonFieldsGetter,
         },
         quote! {
-            pub trait HasPersonFields: HasNameType + HasAgeType {
+            pub trait HasName: HasNameType {
                 fn name(&self) -> &Self::Name;
-
-                fn age(&self) -> &Self::Age;
             }
         },
     )
@@ -29,13 +27,11 @@ fn test_derive_getter_with_generics() {
             provider: PersonFieldsGetter,
         },
         quote! {
-            pub trait HasPersonFields<App>
+            pub trait HasName<App>
             where
-                App: HasNameType + HasAgeType,
+                App: HasNameType,
             {
                 fn name(&self) -> &App::Name;
-
-                fn age(&self) -> &App::Age;
             }
         },
     )

--- a/crates/cgp-component-macro-lib/src/tests/mod.rs
+++ b/crates/cgp-component-macro-lib/src/tests/mod.rs
@@ -2,6 +2,7 @@ pub mod define_preset;
 pub mod delegate_components;
 pub mod derive_component;
 pub mod derive_context;
+pub mod derive_getter;
 pub mod derive_provider;
 pub mod for_each_replace;
 pub mod helper;


### PR DESCRIPTION
## Summary

This PR fixes the incorrect derivation of `#[cgp_getter]` when the getter trait contains generic parameters. Previously, the getter trait did not allow generic parameters to be specified, but this limitation was lifted in `#[cgp_auto_getter]`. So we also need to update `#[cgp_getter]` to better support generic parameters.

## Example

With the new support, we can use `#[cgp_getter]` with traits such as follows:

```rust
#[cgp_getter {
    provider: NameGetter,
}]
pub trait HasName<App>
where
    App: HasNameType,
{
    fn name(&self) -> &App::Name;
}
```