### PR TITLE
Introduce `#[trait_alias]` macro to simplify definition of alias traits

### DIFF
--- a/crates/cgp-component-macro-lib/src/entrypoints/mod.rs
+++ b/crates/cgp-component-macro-lib/src/entrypoints/mod.rs
@@ -10,6 +10,7 @@ mod define_preset;
 mod delegate_components;
 mod re_export_imports;
 mod replace_with;
+mod trait_alias;
 
 pub use cgp_auto_getter::*;
 pub use cgp_component::*;
@@ -23,3 +24,4 @@ pub use define_preset::*;
 pub use delegate_components::*;
 pub use re_export_imports::*;
 pub use replace_with::*;
+pub use trait_alias::*;

--- a/crates/cgp-component-macro-lib/src/entrypoints/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/entrypoints/trait_alias.rs
@@ -1,13 +1,19 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{parse2, ItemTrait};
+use syn::{parse2, Ident, ItemTrait};
 
 use crate::trait_alias::derive_trait_alias;
 
-pub fn trait_alias(_attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+pub fn trait_alias(attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+    let context_ident: Ident = if attr.is_empty() {
+        Ident::new("Context", Span::call_site())
+    } else {
+        parse2(attr)?
+    };
+
     let mut item_trait: ItemTrait = parse2(body)?;
 
-    let item_impl = derive_trait_alias(&mut item_trait)?;
+    let item_impl = derive_trait_alias(&context_ident, &mut item_trait)?;
 
     let out = quote! {
         #item_trait

--- a/crates/cgp-component-macro-lib/src/entrypoints/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/entrypoints/trait_alias.rs
@@ -1,0 +1,19 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse2, ItemTrait};
+
+use crate::trait_alias::derive_trait_alias;
+
+pub fn trait_alias(_attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+    let mut item_trait: ItemTrait = parse2(body)?;
+
+    let item_impl = derive_trait_alias(&mut item_trait)?;
+
+    let out = quote! {
+        #item_trait
+
+        #item_impl
+    };
+
+    Ok(out)
+}

--- a/crates/cgp-component-macro-lib/src/lib.rs
+++ b/crates/cgp-component-macro-lib/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod for_each_replace;
 pub(crate) mod getter_component;
 pub(crate) mod parse;
 pub(crate) mod preset;
+pub(crate) mod trait_alias;
 pub(crate) mod type_component;
 
 #[cfg(test)]

--- a/crates/cgp-component-macro-lib/src/tests/mod.rs
+++ b/crates/cgp-component-macro-lib/src/tests/mod.rs
@@ -7,3 +7,4 @@ pub mod derive_getter;
 pub mod derive_provider;
 pub mod for_each_replace;
 pub mod helper;
+pub mod trait_alias;

--- a/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
@@ -26,12 +26,12 @@ pub fn test_basic_trait_alias() {
 }
 
 #[test]
-pub fn test_trait_alias_with_associated_type() {
+pub fn test_trait_alias_with_associated_type_without_constraints() {
     let derived = trait_alias(
         quote!(),
         quote! {
             pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
-                type FooBar = Self::Foo;
+                type FooBar;
             }
         },
     )
@@ -42,11 +42,11 @@ pub fn test_trait_alias_with_associated_type() {
             type FooBar;
         }
 
-        impl<Context> HasFooAtBar for Context
+        impl<Context, FooBar> HasFooAtBar for Context
         where
-            Context: HasFooAt<Bar>,
+            Context: HasFooAt<Bar, Foo = FooBar>,
         {
-            type FooBar = Self::Foo;
+            type FooBar = FooBar;
         }
     };
 
@@ -59,7 +59,7 @@ pub fn test_trait_alias_with_associated_type_and_constraints() {
         quote!(),
         quote! {
             pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
-                type FooBar: Clone = Self::Foo;
+                type FooBar: Clone;
             }
         },
     )
@@ -70,12 +70,12 @@ pub fn test_trait_alias_with_associated_type_and_constraints() {
             type FooBar: Clone;
         }
 
-        impl<Context> HasFooAtBar for Context
+        impl<Context, FooBar> HasFooAtBar for Context
         where
-            Context: HasFooAt<Bar>,
-            Self::Foo: Clone,
+            Context: HasFooAt<Bar, Foo = FooBar>,
+            FooBar: Clone,
         {
-            type FooBar = Self::Foo;
+            type FooBar = FooBar;
         }
     };
 

--- a/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
@@ -25,7 +25,6 @@ pub fn test_basic_trait_alias() {
     assert_equal_token_stream(&derived, &expected);
 }
 
-
 #[test]
 pub fn test_trait_alias_with_method() {
     let derived = trait_alias(
@@ -57,7 +56,6 @@ pub fn test_trait_alias_with_method() {
 
     assert_equal_token_stream(&derived, &expected);
 }
-
 
 #[test]
 pub fn test_trait_alias_with_associated_type_without_constraints() {

--- a/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
@@ -1,0 +1,54 @@
+use quote::quote;
+
+use crate::tests::helper::equal::assert_equal_token_stream;
+use crate::trait_alias;
+
+#[test]
+pub fn test_basic_trait_alias() {
+    let derived = trait_alias(
+        quote!(),
+        quote! {
+            pub trait CanDoFooBar: CanDoFoo + CanDoBar {}
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {
+        pub trait CanDoFooBar: CanDoFoo + CanDoBar {}
+
+        impl<Context> CanDoFooBar for Context
+        where
+            Context: CanDoFoo + CanDoBar,
+        {}
+    };
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
+pub fn test_trait_alias_with_associated_type() {
+    let derived = trait_alias(
+        quote!(),
+        quote! {
+            pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
+                type FooBar = Self::Foo;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {
+        pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
+            type FooBar;
+        }
+
+        impl<Context> HasFooAtBar for Context
+        where
+            Context: HasFooAt<Bar>,
+        {
+            type FooBar = Self::Foo;
+        }
+    };
+
+    assert_equal_token_stream(&derived, &expected);
+}

--- a/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
@@ -25,6 +25,40 @@ pub fn test_basic_trait_alias() {
     assert_equal_token_stream(&derived, &expected);
 }
 
+
+#[test]
+pub fn test_trait_alias_with_method() {
+    let derived = trait_alias(
+        quote!(),
+        quote! {
+            pub trait CanDoFooBar: CanDoFoo + CanDoBar {
+                fn foo_bar(&self) {
+                    self.foo().bar();
+                }
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {
+        pub trait CanDoFooBar: CanDoFoo + CanDoBar {
+            fn foo_bar(&self);
+        }
+
+        impl<Context> CanDoFooBar for Context
+        where
+            Context: CanDoFoo + CanDoBar,
+        {
+            fn foo_bar(&self) {
+                self.foo().bar();
+            }
+        }
+    };
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+
 #[test]
 pub fn test_trait_alias_with_associated_type_without_constraints() {
     let derived = trait_alias(

--- a/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
+++ b/crates/cgp-component-macro-lib/src/tests/trait_alias.rs
@@ -52,3 +52,32 @@ pub fn test_trait_alias_with_associated_type() {
 
     assert_equal_token_stream(&derived, &expected);
 }
+
+#[test]
+pub fn test_trait_alias_with_associated_type_and_constraints() {
+    let derived = trait_alias(
+        quote!(),
+        quote! {
+            pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
+                type FooBar: Clone = Self::Foo;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {
+        pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
+            type FooBar: Clone;
+        }
+
+        impl<Context> HasFooAtBar for Context
+        where
+            Context: HasFooAt<Bar>,
+            Self::Foo: Clone,
+        {
+            type FooBar = Self::Foo;
+        }
+    };
+
+    assert_equal_token_stream(&derived, &expected);
+}

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -110,39 +110,7 @@ pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
     for bound in supertraits.iter_mut() {
         match bound {
             TypeParamBound::Trait(trait_bound) => {
-                for path in trait_bound.path.segments.iter_mut() {
-                    match &mut path.arguments {
-                        PathArguments::AngleBracketed(generics) => {
-                            let new_generic_args = generics
-                                .args
-                                .clone()
-                                .into_iter()
-                                .filter(|arg| match arg {
-                                    GenericArgument::AssocType(assoc) => match &assoc.ty {
-                                        Type::Path(path) => {
-                                            if let Some(segment) = path.path.segments.first() {
-                                                if segment.ident
-                                                    == Ident::new("Self", Span::call_site())
-                                                {
-                                                    false
-                                                } else {
-                                                    true
-                                                }
-                                            } else {
-                                                true
-                                            }
-                                        }
-                                        _ => true,
-                                    },
-                                    _ => true,
-                                })
-                                .collect();
-
-                            generics.args = new_generic_args;
-                        }
-                        _ => {}
-                    }
-                }
+                filter_assoc_self_constraint(&mut trait_bound.path);
             }
             _ => {}
         }
@@ -171,4 +139,38 @@ pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
     };
 
     Ok(item_impl)
+}
+
+pub fn filter_assoc_self_constraint(path: &mut Path) {
+    for path in path.segments.iter_mut() {
+        match &mut path.arguments {
+            PathArguments::AngleBracketed(generics) => {
+                let new_generic_args = generics
+                    .args
+                    .clone()
+                    .into_iter()
+                    .filter(|arg| match arg {
+                        GenericArgument::AssocType(assoc) => match &assoc.ty {
+                            Type::Path(path) => {
+                                if let Some(segment) = path.path.segments.first() {
+                                    if segment.ident == Ident::new("Self", Span::call_site()) {
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                } else {
+                                    true
+                                }
+                            }
+                            _ => true,
+                        },
+                        _ => true,
+                    })
+                    .collect();
+
+                generics.args = new_generic_args;
+            }
+            _ => {}
+        }
+    }
 }

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -149,22 +149,27 @@ pub fn filter_assoc_self_constraint(path: &mut Path) {
                     .args
                     .clone()
                     .into_iter()
-                    .filter(|arg| match arg {
-                        GenericArgument::AssocType(assoc) => match &assoc.ty {
-                            Type::Path(path) => {
-                                if let Some(segment) = path.path.segments.first() {
-                                    if segment.ident == Ident::new("Self", Span::call_site()) {
-                                        false
-                                    } else {
-                                        true
+                    .filter_map(|mut arg| {
+                        match &mut arg {
+                            GenericArgument::AssocType(assoc) => {
+                                if let Type::Path(path) = &assoc.ty {
+                                    if let Some(segment) = path.path.segments.first() {
+                                        if segment.ident == Ident::new("Self", Span::call_site()) {
+                                            return None;
+                                        }
                                     }
-                                } else {
-                                    true
                                 }
                             }
-                            _ => true,
-                        },
-                        _ => true,
+                            GenericArgument::Constraint(constraint) => {
+                                for bound in constraint.bounds.iter_mut() {
+                                    if let TypeParamBound::Trait(trait_bound) = bound {
+                                        filter_assoc_self_constraint(&mut trait_bound.path);
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                        Some(arg)
                     })
                     .collect();
 

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -33,7 +33,7 @@ pub fn derive_trait_alias(
                     attrs: trait_item_type.attrs.clone(),
                     vis: Visibility::Inherited,
                     defaultness: None,
-                    type_token: trait_item_type.type_token.clone(),
+                    type_token: trait_item_type.type_token,
                     ident: trait_item_type.ident.clone(),
                     generics: trait_item_type.generics.clone(),
                     eq_token: Eq(Span::call_site()),
@@ -85,14 +85,14 @@ pub fn derive_trait_alias(
                     attrs: trait_item_const.attrs.clone(),
                     vis: Visibility::Inherited,
                     defaultness: None,
-                    const_token: trait_item_const.const_token.clone(),
+                    const_token: trait_item_const.const_token,
                     ident: trait_item_const.ident.clone(),
                     generics: trait_item_const.generics.clone(),
-                    colon_token: trait_item_const.colon_token.clone(),
+                    colon_token: trait_item_const.colon_token,
                     ty: trait_item_const.ty.clone(),
                     eq_token,
                     expr: const_expr,
-                    semi_token: trait_item_const.semi_token.clone(),
+                    semi_token: trait_item_const.semi_token,
                 };
 
                 impl_items.push(ImplItem::Const(impl_item_const));
@@ -111,11 +111,8 @@ pub fn derive_trait_alias(
     let mut supertraits = item_trait.supertraits.clone();
 
     for bound in supertraits.iter_mut() {
-        match bound {
-            TypeParamBound::Trait(trait_bound) => {
-                filter_assoc_self_constraint(&mut trait_bound.path);
-            }
-            _ => {}
+        if let TypeParamBound::Trait(trait_bound) = bound {
+            filter_assoc_self_constraint(&mut trait_bound.path);
         }
     }
 
@@ -132,12 +129,12 @@ pub fn derive_trait_alias(
     let item_impl = ItemImpl {
         attrs: item_trait.attrs.clone(),
         defaultness: None,
-        unsafety: item_trait.unsafety.clone(),
+        unsafety: item_trait.unsafety,
         impl_token: Impl(Span::call_site()),
         generics: impl_generics,
         trait_: Some((None, trait_path, For(Span::call_site()))),
         self_ty: Box::new(context_type),
-        brace_token: item_trait.brace_token.clone(),
+        brace_token: item_trait.brace_token,
         items: impl_items,
     };
 
@@ -146,39 +143,36 @@ pub fn derive_trait_alias(
 
 pub fn filter_assoc_self_constraint(path: &mut Path) {
     for path in path.segments.iter_mut() {
-        match &mut path.arguments {
-            PathArguments::AngleBracketed(generics) => {
-                let new_generic_args = generics
-                    .args
-                    .clone()
-                    .into_iter()
-                    .filter_map(|mut arg| {
-                        match &mut arg {
-                            GenericArgument::AssocType(assoc) => {
-                                if let Type::Path(path) = &assoc.ty {
-                                    if let Some(segment) = path.path.segments.first() {
-                                        if segment.ident == Ident::new("Self", Span::call_site()) {
-                                            return None;
-                                        }
+        if let PathArguments::AngleBracketed(generics) = &mut path.arguments {
+            let new_generic_args = generics
+                .args
+                .clone()
+                .into_iter()
+                .filter_map(|mut arg| {
+                    match &mut arg {
+                        GenericArgument::AssocType(assoc) => {
+                            if let Type::Path(path) = &assoc.ty {
+                                if let Some(segment) = path.path.segments.first() {
+                                    if segment.ident == Ident::new("Self", Span::call_site()) {
+                                        return None;
                                     }
                                 }
                             }
-                            GenericArgument::Constraint(constraint) => {
-                                for bound in constraint.bounds.iter_mut() {
-                                    if let TypeParamBound::Trait(trait_bound) = bound {
-                                        filter_assoc_self_constraint(&mut trait_bound.path);
-                                    }
-                                }
-                            }
-                            _ => {}
                         }
-                        Some(arg)
-                    })
-                    .collect();
+                        GenericArgument::Constraint(constraint) => {
+                            for bound in constraint.bounds.iter_mut() {
+                                if let TypeParamBound::Trait(trait_bound) = bound {
+                                    filter_assoc_self_constraint(&mut trait_bound.path);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    Some(arg)
+                })
+                .collect();
 
-                generics.args = new_generic_args;
-            }
-            _ => {}
+            generics.args = new_generic_args;
         }
     }
 }

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -40,11 +40,17 @@ pub fn derive_trait_alias(
                     #item_type_ident
                 })?;
 
-                for bound in trait_item_type.bounds.iter() {
-                    assoc_bounds.push(parse2(quote! {
-                        #item_type_ident : #bound
-                    })?);
+                let mut current_assoc_bounds = trait_item_type.bounds.clone();
+
+                for bound in current_assoc_bounds.iter_mut() {
+                    if let TypeParamBound::Trait(bound) = bound {
+                        filter_assoc_self_constraint(&mut bound.path);
+                    }
                 }
+
+                assoc_bounds.push(parse2(quote! {
+                    #item_type_ident : #current_assoc_bounds
+                })?);
 
                 let impl_item_type = ImplItemType {
                     attrs: trait_item_type.attrs.clone(),

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -13,28 +13,36 @@ pub fn derive_trait_alias(
 ) -> syn::Result<ItemImpl> {
     let mut impl_items: Vec<ImplItem> = Vec::new();
 
+    let mut assoc_idents: Vec<Ident> = Vec::new();
     let mut assoc_bounds: Vec<WherePredicate> = Vec::new();
 
     for trait_item in item_trait.items.iter_mut() {
         match trait_item {
             TraitItem::Type(trait_item_type) => {
-                let type_impl = trait_item_type
-                    .default
-                    .as_ref()
-                    .ok_or_else(|| {
-                        Error::new_spanned(
-                            &trait_item_type,
-                            "type item require assignment to concrete type",
-                        )
-                    })?
-                    .1
-                    .clone();
+                // let type_impl = trait_item_type
+                //     .default
+                //     .as_ref()
+                //     .ok_or_else(|| {
+                //         Error::new_spanned(
+                //             &trait_item_type,
+                //             "type item require assignment to concrete type",
+                //         )
+                //     })?
+                //     .1
+                //     .clone();
 
                 trait_item_type.default.take();
 
+                let item_type_ident = &trait_item_type.ident;
+                assoc_idents.push(item_type_ident.clone());
+
+                let type_impl = parse2(quote! {
+                    #item_type_ident
+                })?;
+
                 for bound in trait_item_type.bounds.iter() {
                     assoc_bounds.push(parse2(quote! {
-                        #type_impl : #bound
+                        #item_type_ident : #bound
                     })?);
                 }
 
@@ -113,9 +121,16 @@ pub fn derive_trait_alias(
     let context_type: Type = parse2(quote! { #context_ident })?;
 
     let mut impl_generics = item_trait.generics.clone();
+
     impl_generics
         .params
         .push(parse2(context_type.to_token_stream())?);
+
+    for assoc_ident in assoc_idents {
+        impl_generics
+            .params
+            .push(parse2(assoc_ident.to_token_stream())?);
+    }
 
     let mut supertraits = item_trait.supertraits.clone();
 
@@ -155,35 +170,60 @@ pub fn derive_trait_alias(
 pub fn filter_assoc_self_constraint(path: &mut Path) {
     for path in path.segments.iter_mut() {
         if let PathArguments::AngleBracketed(generics) = &mut path.arguments {
-            let new_generic_args = generics
-                .args
-                .clone()
-                .into_iter()
-                .filter_map(|mut arg| {
-                    match &mut arg {
-                        GenericArgument::AssocType(assoc) => {
-                            if let Type::Path(path) = &assoc.ty {
-                                if let Some(segment) = path.path.segments.first() {
-                                    if segment.ident == Ident::new("Self", Span::call_site()) {
-                                        return None;
-                                    }
-                                }
-                            }
-                        }
-                        GenericArgument::Constraint(constraint) => {
-                            for bound in constraint.bounds.iter_mut() {
-                                if let TypeParamBound::Trait(trait_bound) = bound {
-                                    filter_assoc_self_constraint(&mut trait_bound.path);
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                    Some(arg)
-                })
-                .collect();
+            for arg in generics.args.iter_mut() {
+                match arg {
+                    GenericArgument::AssocType(assoc) => {
+                        if let Type::Path(path) = &mut assoc.ty {
+                            if let Some(segment) = path.path.segments.first() {
+                                if segment.ident == Ident::new("Self", Span::call_site()) {
+                                    let mut new_segments = path.path.segments.clone().into_iter();
+                                    new_segments.next();
 
-            generics.args = new_generic_args;
+                                    path.path.segments = new_segments.collect();
+                                }
+                            }
+                        }
+                    }
+                    GenericArgument::Constraint(constraint) => {
+                        for bound in constraint.bounds.iter_mut() {
+                            if let TypeParamBound::Trait(trait_bound) = bound {
+                                filter_assoc_self_constraint(&mut trait_bound.path);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // let new_generic_args = generics
+            //     .args
+            //     .clone()
+            //     .into_iter()
+            //     .filter_map(|mut arg| {
+            //         match &mut arg {
+            //             GenericArgument::AssocType(assoc) => {
+            //                 if let Type::Path(path) = &assoc.ty {
+            //                     if let Some(segment) = path.path.segments.first() {
+            //                         if segment.ident == Ident::new("Self", Span::call_site()) {
+            //                             return None;
+            //                         }
+            //                     }
+            //                 }
+            //             }
+            //             GenericArgument::Constraint(constraint) => {
+            //                 for bound in constraint.bounds.iter_mut() {
+            //                     if let TypeParamBound::Trait(trait_bound) = bound {
+            //                         filter_assoc_self_constraint(&mut trait_bound.path);
+            //                     }
+            //                 }
+            //             }
+            //             _ => {}
+            //         }
+            //         Some(arg)
+            //     })
+            //     .collect();
+
+            // generics.args = new_generic_args;
         }
     }
 }

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -2,8 +2,8 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::token::{Eq, For, Impl, Semi};
 use syn::{
-    parse2, Error, ImplItem, ImplItemConst, ImplItemFn, ImplItemType, ItemImpl, ItemTrait, Path,
-    TraitItem, Type, Visibility,
+    parse2, Error, GenericArgument, Ident, ImplItem, ImplItemConst, ImplItemFn, ImplItemType,
+    ItemImpl, ItemTrait, Path, PathArguments, TraitItem, Type, TypeParamBound, Visibility,
 };
 
 pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
@@ -105,7 +105,48 @@ pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
         .params
         .push(parse2(context_type.to_token_stream())?);
 
-    let supertraits = &item_trait.supertraits;
+    let mut supertraits = item_trait.supertraits.clone();
+
+    for bound in supertraits.iter_mut() {
+        match bound {
+            TypeParamBound::Trait(trait_bound) => {
+                for path in trait_bound.path.segments.iter_mut() {
+                    match &mut path.arguments {
+                        PathArguments::AngleBracketed(generics) => {
+                            let new_generic_args = generics
+                                .args
+                                .clone()
+                                .into_iter()
+                                .filter(|arg| match arg {
+                                    GenericArgument::AssocType(assoc) => match &assoc.ty {
+                                        Type::Path(path) => {
+                                            if let Some(segment) = path.path.segments.first() {
+                                                if segment.ident
+                                                    == Ident::new("Self", Span::call_site())
+                                                {
+                                                    false
+                                                } else {
+                                                    true
+                                                }
+                                            } else {
+                                                true
+                                            }
+                                        }
+                                        _ => true,
+                                    },
+                                    _ => true,
+                                })
+                                .collect();
+
+                            generics.args = new_generic_args;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
 
     let where_clause = impl_generics.make_where_clause();
     where_clause.predicates.push(parse2(quote! {

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -19,18 +19,6 @@ pub fn derive_trait_alias(
     for trait_item in item_trait.items.iter_mut() {
         match trait_item {
             TraitItem::Type(trait_item_type) => {
-                // let type_impl = trait_item_type
-                //     .default
-                //     .as_ref()
-                //     .ok_or_else(|| {
-                //         Error::new_spanned(
-                //             &trait_item_type,
-                //             "type item require assignment to concrete type",
-                //         )
-                //     })?
-                //     .1
-                //     .clone();
-
                 trait_item_type.default.take();
 
                 let item_type_ident = &trait_item_type.ident;
@@ -202,36 +190,6 @@ pub fn filter_assoc_self_constraint(path: &mut Path) {
                     _ => {}
                 }
             }
-
-            // let new_generic_args = generics
-            //     .args
-            //     .clone()
-            //     .into_iter()
-            //     .filter_map(|mut arg| {
-            //         match &mut arg {
-            //             GenericArgument::AssocType(assoc) => {
-            //                 if let Type::Path(path) = &assoc.ty {
-            //                     if let Some(segment) = path.path.segments.first() {
-            //                         if segment.ident == Ident::new("Self", Span::call_site()) {
-            //                             return None;
-            //                         }
-            //                     }
-            //                 }
-            //             }
-            //             GenericArgument::Constraint(constraint) => {
-            //                 for bound in constraint.bounds.iter_mut() {
-            //                     if let TypeParamBound::Trait(trait_bound) = bound {
-            //                         filter_assoc_self_constraint(&mut trait_bound.path);
-            //                     }
-            //                 }
-            //             }
-            //             _ => {}
-            //         }
-            //         Some(arg)
-            //     })
-            //     .collect();
-
-            // generics.args = new_generic_args;
         }
     }
 }

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -6,7 +6,10 @@ use syn::{
     ItemImpl, ItemTrait, Path, PathArguments, TraitItem, Type, TypeParamBound, Visibility,
 };
 
-pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
+pub fn derive_trait_alias(
+    context_ident: &Ident,
+    item_trait: &mut ItemTrait,
+) -> syn::Result<ItemImpl> {
     let mut impl_items: Vec<ImplItem> = Vec::new();
 
     for trait_item in item_trait.items.iter_mut() {
@@ -98,7 +101,7 @@ pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
         }
     }
 
-    let context_type: Type = parse2(quote! { __Context__ })?;
+    let context_type: Type = parse2(quote! { #context_ident })?;
 
     let mut impl_generics = item_trait.generics.clone();
     impl_generics

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -40,17 +40,19 @@ pub fn derive_trait_alias(
                     #item_type_ident
                 })?;
 
-                let mut current_assoc_bounds = trait_item_type.bounds.clone();
+                if !trait_item_type.bounds.is_empty() {
+                    let mut current_assoc_bounds = trait_item_type.bounds.clone();
 
-                for bound in current_assoc_bounds.iter_mut() {
-                    if let TypeParamBound::Trait(bound) = bound {
-                        filter_assoc_self_constraint(&mut bound.path);
+                    for bound in current_assoc_bounds.iter_mut() {
+                        if let TypeParamBound::Trait(bound) = bound {
+                            filter_assoc_self_constraint(&mut bound.path);
+                        }
                     }
-                }
 
-                assoc_bounds.push(parse2(quote! {
-                    #item_type_ident : #current_assoc_bounds
-                })?);
+                    assoc_bounds.push(parse2(quote! {
+                        #item_type_ident : #current_assoc_bounds
+                    })?);
+                }
 
                 let impl_item_type = ImplItemType {
                     attrs: trait_item_type.attrs.clone(),

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -4,6 +4,7 @@ use syn::token::{Eq, For, Impl, Semi};
 use syn::{
     parse2, Error, GenericArgument, Ident, ImplItem, ImplItemConst, ImplItemFn, ImplItemType,
     ItemImpl, ItemTrait, Path, PathArguments, TraitItem, Type, TypeParamBound, Visibility,
+    WherePredicate,
 };
 
 pub fn derive_trait_alias(
@@ -11,6 +12,8 @@ pub fn derive_trait_alias(
     item_trait: &mut ItemTrait,
 ) -> syn::Result<ItemImpl> {
     let mut impl_items: Vec<ImplItem> = Vec::new();
+
+    let mut assoc_bounds: Vec<WherePredicate> = Vec::new();
 
     for trait_item in item_trait.items.iter_mut() {
         match trait_item {
@@ -28,6 +31,12 @@ pub fn derive_trait_alias(
                     .clone();
 
                 trait_item_type.default.take();
+
+                for bound in trait_item_type.bounds.iter() {
+                    assoc_bounds.push(parse2(quote! {
+                        #type_impl : #bound
+                    })?);
+                }
 
                 let impl_item_type = ImplItemType {
                     attrs: trait_item_type.attrs.clone(),
@@ -120,6 +129,8 @@ pub fn derive_trait_alias(
     where_clause.predicates.push(parse2(quote! {
         #context_type: #supertraits
     })?);
+
+    where_clause.predicates.extend(assoc_bounds);
 
     let trait_name = &item_trait.ident;
     let (_, type_generics, _) = item_trait.generics.split_for_impl();

--- a/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/derive.rs
@@ -1,0 +1,133 @@
+use proc_macro2::Span;
+use quote::{quote, ToTokens};
+use syn::token::{Eq, For, Impl, Semi};
+use syn::{
+    parse2, Error, ImplItem, ImplItemConst, ImplItemFn, ImplItemType, ItemImpl, ItemTrait, Path,
+    TraitItem, Type, Visibility,
+};
+
+pub fn derive_trait_alias(item_trait: &mut ItemTrait) -> syn::Result<ItemImpl> {
+    let mut impl_items: Vec<ImplItem> = Vec::new();
+
+    for trait_item in item_trait.items.iter_mut() {
+        match trait_item {
+            TraitItem::Type(trait_item_type) => {
+                let type_impl = trait_item_type
+                    .default
+                    .as_ref()
+                    .ok_or_else(|| {
+                        Error::new_spanned(
+                            &trait_item_type,
+                            "type item require assignment to concrete type",
+                        )
+                    })?
+                    .1
+                    .clone();
+
+                trait_item_type.default.take();
+
+                let impl_item_type = ImplItemType {
+                    attrs: trait_item_type.attrs.clone(),
+                    vis: Visibility::Inherited,
+                    defaultness: None,
+                    type_token: trait_item_type.type_token.clone(),
+                    ident: trait_item_type.ident.clone(),
+                    generics: trait_item_type.generics.clone(),
+                    eq_token: Eq(Span::call_site()),
+                    ty: type_impl,
+                    semi_token: Semi(Span::call_site()),
+                };
+
+                impl_items.push(ImplItem::Type(impl_item_type));
+            }
+            TraitItem::Fn(trait_item_fn) => {
+                let fn_block = trait_item_fn
+                    .default
+                    .as_ref()
+                    .ok_or_else(|| {
+                        Error::new_spanned(
+                            &trait_item_fn,
+                            "function item require implementation block",
+                        )
+                    })?
+                    .clone();
+
+                trait_item_fn.default.take();
+
+                let impl_item_fn = ImplItemFn {
+                    attrs: trait_item_fn.attrs.clone(),
+                    vis: Visibility::Inherited,
+                    defaultness: None,
+                    sig: trait_item_fn.sig.clone(),
+                    block: fn_block,
+                };
+
+                impl_items.push(ImplItem::Fn(impl_item_fn));
+            }
+            TraitItem::Const(trait_item_const) => {
+                let (eq_token, const_expr) = trait_item_const
+                    .default
+                    .as_ref()
+                    .ok_or_else(|| {
+                        Error::new_spanned(
+                            &trait_item_const,
+                            "const item require implementation expression",
+                        )
+                    })?
+                    .clone();
+
+                trait_item_const.default.take();
+
+                let impl_item_const = ImplItemConst {
+                    attrs: trait_item_const.attrs.clone(),
+                    vis: Visibility::Inherited,
+                    defaultness: None,
+                    const_token: trait_item_const.const_token.clone(),
+                    ident: trait_item_const.ident.clone(),
+                    generics: trait_item_const.generics.clone(),
+                    colon_token: trait_item_const.colon_token.clone(),
+                    ty: trait_item_const.ty.clone(),
+                    eq_token,
+                    expr: const_expr,
+                    semi_token: trait_item_const.semi_token.clone(),
+                };
+
+                impl_items.push(ImplItem::Const(impl_item_const));
+            }
+            _ => return Err(Error::new_spanned(&trait_item, "unsupported trait item")),
+        }
+    }
+
+    let context_type: Type = parse2(quote! { __Context__ })?;
+
+    let mut impl_generics = item_trait.generics.clone();
+    impl_generics
+        .params
+        .push(parse2(context_type.to_token_stream())?);
+
+    let supertraits = &item_trait.supertraits;
+
+    let where_clause = impl_generics.make_where_clause();
+    where_clause.predicates.push(parse2(quote! {
+        #context_type: #supertraits
+    })?);
+
+    let trait_name = &item_trait.ident;
+    let (_, type_generics, _) = item_trait.generics.split_for_impl();
+
+    let trait_path: Path = parse2(quote! { #trait_name #type_generics })?;
+
+    let item_impl = ItemImpl {
+        attrs: item_trait.attrs.clone(),
+        defaultness: None,
+        unsafety: item_trait.unsafety.clone(),
+        impl_token: Impl(Span::call_site()),
+        generics: impl_generics,
+        trait_: Some((None, trait_path, For(Span::call_site()))),
+        self_ty: Box::new(context_type),
+        brace_token: item_trait.brace_token.clone(),
+        items: impl_items,
+    };
+
+    Ok(item_impl)
+}

--- a/crates/cgp-component-macro-lib/src/trait_alias/mod.rs
+++ b/crates/cgp-component-macro-lib/src/trait_alias/mod.rs
@@ -1,0 +1,3 @@
+mod derive;
+
+pub use derive::*;

--- a/crates/cgp-component-macro/src/lib.rs
+++ b/crates/cgp-component-macro/src/lib.rs
@@ -79,6 +79,13 @@ pub fn cgp_context(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn trait_alias(attr: TokenStream, item: TokenStream) -> TokenStream {
+    cgp_component_macro_lib::trait_alias(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_attribute]
 pub fn re_export_imports(attrs: TokenStream, body: TokenStream) -> TokenStream {
     cgp_component_macro_lib::re_export_imports(attrs.into(), body.into())
         .unwrap_or_else(syn::Error::into_compile_error)

--- a/crates/cgp-error/src/traits/has_async_error_type.rs
+++ b/crates/cgp-error/src/traits/has_async_error_type.rs
@@ -1,22 +1,14 @@
 use cgp_async::Async;
+use cgp_component_macro::trait_alias;
 
 use crate::traits::HasErrorType;
 use crate::{CanRaiseError, CanWrapError};
 
+#[trait_alias]
 pub trait HasAsyncErrorType: Async + HasErrorType<Error: Async> {}
 
-impl<Context> HasAsyncErrorType for Context where Context: Async + HasErrorType<Error: Async> {}
-
+#[trait_alias]
 pub trait CanRaiseAsyncError<SourceError>: HasAsyncErrorType + CanRaiseError<SourceError> {}
 
-impl<Context, SourceError> CanRaiseAsyncError<SourceError> for Context where
-    Context: HasAsyncErrorType + CanRaiseError<SourceError>
-{
-}
-
+#[trait_alias]
 pub trait CanWrapAsyncError<SourceError>: HasAsyncErrorType + CanWrapError<SourceError> {}
-
-impl<Context, SourceError> CanWrapAsyncError<SourceError> for Context where
-    Context: HasAsyncErrorType + CanWrapError<SourceError>
-{
-}


### PR DESCRIPTION
## Summary

This PR introduces a new `#[trait_alias]` macro, that can be used to simplify the definition of alias traits with blanket implementations. Using the macro, the blanket implementation would be derived automatically, thereby saving up to 50% or more code for the trait alias definition.

## Example

The `HasAsyncErrorType` trait is now defined as follows:

```rust
#[trait_alias]
pub trait HasAsyncErrorType: Async + HasErrorType<Error: Async> {}
```

The macro now expands the following blanket implementation automatically:

```rust
impl<Context> HasAsyncErrorType for Context 
where
    Context: Async + HasErrorType<Error: Async> {}
```

## Associated Items

The `#[trait_alias]` macro can also be used to automatically derive associated types and methods. For example:

```rust
#[trait_alias]
pub trait HasFooAtBar: HasFooAt<Bar, Foo = Self::FooBar> {
    type FooBar: Clone;
}
```

would generate the blanket impl:

```rust
impl<Context, FooBar> HasFooAtBar for Context
where
    Context: HasFooAt<Bar, Foo = FooBar>,
    FooBar: Clone,
{
    type FooBar = FooBar;
}
```

And given the following:

```rust
#[trait_alias]
pub trait CanDoFooBar: CanDoFoo + CanDoBar {
    fn foo_bar(&self) {
        self.foo().bar();
    }
}
```

Would be desugared into:

```rust
pub trait CanDoFooBar: CanDoFoo + CanDoBar {
    fn foo_bar(&self);
}

impl<Context> CanDoFooBar for Context
where
    Context: CanDoFoo + CanDoBar,
{
    fn foo_bar(&self) {
        self.foo().bar();
    }
}
```