### PR TITLE
Refactoring and Improvements on `#[cgp_getter]`

### DIFF
--- a/crates/cgp-component-macro-lib/src/getter_component/blanket.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/blanket.rs
@@ -6,6 +6,7 @@ use syn::{parse2, Ident, ItemImpl, ItemTrait};
 
 use crate::getter_component::getter_field::GetterField;
 use crate::getter_component::symbol::symbol_from_string;
+use crate::getter_component::{derive_getter_method, ContextArg};
 
 pub fn derive_blanket_impl(
     context_type: &Ident,
@@ -19,39 +20,26 @@ pub fn derive_blanket_impl(
     let mut methods: TokenStream = TokenStream::new();
 
     for field in fields {
-        let field_name = &field.field_name;
         let provider_type = &field.provider_type;
         let field_symbol = symbol_from_string(&field.field_name.to_string());
 
-        let phantom_arg = match &field.phantom {
-            Some(phantom) => {
-                quote! {
-                    , _phantom: #phantom
-                }
-            }
-            None => TokenStream::new(),
-        };
+        let method = derive_getter_method(
+            &ContextArg::SelfArg,
+            field,
+            Some(quote! { ::< #field_symbol > }),
+            None,
+        );
+
+        methods.extend(method);
 
         if field.field_mut.is_none() {
             constraints.push(parse2(quote! {
                 HasField< #field_symbol, Value = #provider_type >
             })?);
-
-            methods.extend(quote! {
-                fn #field_name( &self #phantom_arg ) -> & #provider_type {
-                    self.get_field( ::core::marker::PhantomData::< #field_symbol > )
-                }
-            });
         } else {
             constraints.push(parse2(quote! {
                 HasFieldMut< #field_symbol, Value = #provider_type >
             })?);
-
-            methods.extend(quote! {
-                fn #field_name( &mut self #phantom_arg ) -> &mut #provider_type {
-                    self.get_field_mut( ::core::marker::PhantomData::< #field_symbol > )
-                }
-            });
         }
     }
 

--- a/crates/cgp-component-macro-lib/src/getter_component/blanket.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/blanket.rs
@@ -6,7 +6,7 @@ use syn::{parse2, Ident, ItemImpl, ItemTrait};
 
 use crate::getter_component::getter_field::GetterField;
 use crate::getter_component::symbol::symbol_from_string;
-use crate::getter_component::{derive_getter_method, ContextArg};
+use crate::getter_component::{derive_getter_constraint, derive_getter_method, ContextArg};
 
 pub fn derive_blanket_impl(
     context_type: &Ident,
@@ -20,7 +20,6 @@ pub fn derive_blanket_impl(
     let mut methods: TokenStream = TokenStream::new();
 
     for field in fields {
-        let provider_type = &field.provider_type;
         let field_symbol = symbol_from_string(&field.field_name.to_string());
 
         let method = derive_getter_method(
@@ -32,15 +31,9 @@ pub fn derive_blanket_impl(
 
         methods.extend(method);
 
-        if field.field_mut.is_none() {
-            constraints.push(parse2(quote! {
-                HasField< #field_symbol, Value = #provider_type >
-            })?);
-        } else {
-            constraints.push(parse2(quote! {
-                HasFieldMut< #field_symbol, Value = #provider_type >
-            })?);
-        }
+        let constraint = derive_getter_constraint(field, quote! { #field_symbol })?;
+
+        constraints.push(constraint);
     }
 
     let (_, type_generics, _) = consumer_trait.generics.split_for_impl();

--- a/crates/cgp-component-macro-lib/src/getter_component/blanket.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/blanket.rs
@@ -23,13 +23,22 @@ pub fn derive_blanket_impl(
         let provider_type = &field.provider_type;
         let field_symbol = symbol_from_string(&field.field_name.to_string());
 
+        let phantom_arg = match &field.phantom {
+            Some(phantom) => {
+                quote! {
+                    , _phantom: #phantom
+                }
+            }
+            None => TokenStream::new(),
+        };
+
         if field.field_mut.is_none() {
             constraints.push(parse2(quote! {
                 HasField< #field_symbol, Value = #provider_type >
             })?);
 
             methods.extend(quote! {
-                fn #field_name( &self ) -> & #provider_type {
+                fn #field_name( &self #phantom_arg ) -> & #provider_type {
                     self.get_field( ::core::marker::PhantomData::< #field_symbol > )
                 }
             });
@@ -39,7 +48,7 @@ pub fn derive_blanket_impl(
             })?);
 
             methods.extend(quote! {
-                fn #field_name( &mut self ) -> &mut #provider_type {
+                fn #field_name( &mut self #phantom_arg ) -> &mut #provider_type {
                     self.get_field_mut( ::core::marker::PhantomData::< #field_symbol > )
                 }
             });

--- a/crates/cgp-component-macro-lib/src/getter_component/constraint.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/constraint.rs
@@ -1,0 +1,24 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse2, TypeParamBound};
+
+use crate::getter_component::GetterField;
+
+pub fn derive_getter_constraint(
+    spec: &GetterField,
+    field_symbol: TokenStream,
+) -> syn::Result<TypeParamBound> {
+    let provider_type = &spec.provider_type;
+
+    let constraint = if spec.field_mut.is_none() {
+        quote! {
+            HasField< #field_symbol, Value = #provider_type >
+        }
+    } else {
+        quote! {
+            HasFieldMut< #field_symbol, Value = #provider_type >
+        }
+    };
+
+    parse2(constraint)
+}

--- a/crates/cgp-component-macro-lib/src/getter_component/constraint.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/constraint.rs
@@ -8,7 +8,7 @@ pub fn derive_getter_constraint(
     spec: &GetterField,
     field_symbol: TokenStream,
 ) -> syn::Result<TypeParamBound> {
-    let provider_type = &spec.provider_type;
+    let provider_type = &spec.field_type;
 
     let constraint = if spec.field_mut.is_none() {
         quote! {

--- a/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
@@ -1,11 +1,9 @@
 use syn::token::Mut;
 use syn::{Ident, Type};
 
-use crate::parse::SimpleType;
-
 pub struct GetterField {
     pub field_name: Ident,
     pub provider_type: Type,
     pub field_mut: Option<Mut>,
-    pub phantom: Option<SimpleType>,
+    pub phantom: Option<Type>,
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
@@ -1,8 +1,11 @@
 use syn::token::Mut;
 use syn::{Ident, Type};
 
+use crate::parse::SimpleType;
+
 pub struct GetterField {
     pub field_name: Ident,
     pub provider_type: Type,
     pub field_mut: Option<Mut>,
+    pub phantom: Option<SimpleType>,
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
@@ -5,5 +5,12 @@ pub struct GetterField {
     pub field_name: Ident,
     pub provider_type: Type,
     pub field_mut: Option<Mut>,
-    pub phantom: Option<Type>,
+    pub phantom_arg_type: Option<Type>,
+    pub field_mode: FieldMode,
+}
+
+pub enum FieldMode {
+    Reference,
+    AsRef,
+    Clone,
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
@@ -12,5 +12,6 @@ pub struct GetterField {
 pub enum FieldMode {
     Reference,
     AsRef,
+    Str,
     Clone,
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/getter_field.rs
@@ -3,7 +3,8 @@ use syn::{Ident, Type};
 
 pub struct GetterField {
     pub field_name: Ident,
-    pub provider_type: Type,
+    pub field_type: Type,
+    pub return_type: Type,
     pub field_mut: Option<Mut>,
     pub phantom_arg_type: Option<Type>,
     pub field_mode: FieldMode,
@@ -11,7 +12,7 @@ pub struct GetterField {
 
 pub enum FieldMode {
     Reference,
-    AsRef,
+    OptionRef,
     Str,
     Clone,
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::Ident;
 
 use crate::getter_component::{FieldMode, GetterField};
@@ -74,7 +74,7 @@ pub fn derive_getter_method(
 
     let call_expr = match spec.field_mode {
         FieldMode::Reference => call_expr,
-        FieldMode::AsRef => quote! {
+        FieldMode::AsRef | FieldMode::Str => quote! {
             #call_expr .as_ref()
         },
         FieldMode::Clone => quote! {
@@ -82,10 +82,15 @@ pub fn derive_getter_method(
         },
     };
 
-    let return_type = if spec.field_mut.is_none() {
-        quote! { & #provider_type }
-    } else {
-        quote! { & mut #provider_type }
+    let return_type = match &spec.field_mode {
+        FieldMode::Reference | FieldMode::Str => {
+            if spec.field_mut.is_none() {
+                quote! { & #provider_type }
+            } else {
+                quote! { & mut #provider_type }
+            }
+        }
+        FieldMode::Clone | FieldMode::AsRef => provider_type.to_token_stream(),
     };
 
     quote! {

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -73,9 +73,28 @@ pub fn derive_getter_method(
 
     let call_expr = match spec.field_mode {
         FieldMode::Reference => call_expr,
-        FieldMode::OptionRef | FieldMode::Str => quote! {
-            #call_expr .as_ref()
-        },
+        FieldMode::OptionRef => {
+            if spec.field_mut.is_none() {
+                quote! {
+                    #call_expr .as_ref()
+                }
+            } else {
+                quote! {
+                    #call_expr .as_mut()
+                }
+            }
+        }
+        FieldMode::Str => {
+            if spec.field_mut.is_none() {
+                quote! {
+                    #call_expr .as_str()
+                }
+            } else {
+                quote! {
+                    #call_expr .as_mut_str()
+                }
+            }
+        }
         FieldMode::Clone => quote! {
             #call_expr .clone()
         },

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::Ident;
 
 use crate::getter_component::{FieldMode, GetterField};
@@ -16,7 +16,6 @@ pub fn derive_getter_method(
     provider_ident: Option<Ident>,
 ) -> TokenStream {
     let field_name = &spec.field_name;
-    let provider_type = &spec.provider_type;
 
     let phantom_arg = match &spec.phantom_arg_type {
         Some(phantom) => {
@@ -74,7 +73,7 @@ pub fn derive_getter_method(
 
     let call_expr = match spec.field_mode {
         FieldMode::Reference => call_expr,
-        FieldMode::AsRef | FieldMode::Str => quote! {
+        FieldMode::OptionRef | FieldMode::Str => quote! {
             #call_expr .as_ref()
         },
         FieldMode::Clone => quote! {
@@ -82,16 +81,7 @@ pub fn derive_getter_method(
         },
     };
 
-    let return_type = match &spec.field_mode {
-        FieldMode::Reference | FieldMode::Str => {
-            if spec.field_mut.is_none() {
-                quote! { & #provider_type }
-            } else {
-                quote! { & mut #provider_type }
-            }
-        }
-        FieldMode::Clone | FieldMode::AsRef => provider_type.to_token_stream(),
-    };
+    let return_type = &spec.return_type;
 
     quote! {
         fn #field_name( #context_fn_arg #phantom_arg ) -> #return_type {

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -72,8 +72,14 @@ pub fn derive_getter_method(
         }
     };
 
+    let return_type = if spec.field_mut.is_none() {
+        quote! { & #provider_type }
+    } else {
+        quote! { & mut #provider_type }
+    };
+
     quote! {
-        fn #field_name( #context_fn_arg #phantom_arg ) -> & #provider_type {
+        fn #field_name( #context_fn_arg #phantom_arg ) -> #return_type {
             #call_expr
         }
     }

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -1,0 +1,80 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+use crate::getter_component::GetterField;
+
+pub enum ContextArg {
+    SelfArg,
+    Ident(Ident),
+}
+
+pub fn derive_getter_method(
+    context_arg: &ContextArg,
+    spec: &GetterField,
+    phantom_generics: Option<TokenStream>,
+    provider_ident: Option<Ident>,
+) -> TokenStream {
+    let field_name = &spec.field_name;
+    let provider_type = &spec.provider_type;
+
+    let phantom_arg = match &spec.phantom {
+        Some(phantom) => {
+            quote! {
+                , _phantom: #phantom
+            }
+        }
+        None => TokenStream::new(),
+    };
+
+    let context_fn_arg = match &context_arg {
+        ContextArg::SelfArg => {
+            if spec.field_mut.is_none() {
+                quote! { &self }
+            } else {
+                quote! { &mut self }
+            }
+        }
+        ContextArg::Ident(context_type) => {
+            if spec.field_mut.is_none() {
+                quote! { context: & #context_type}
+            } else {
+                quote! { context: &mut #context_type }
+            }
+        }
+    };
+
+    let get_field_method = if spec.field_mut.is_none() {
+        quote! { get_field }
+    } else {
+        quote! { get_field_mut }
+    };
+
+    let context_var = match &context_arg {
+        ContextArg::SelfArg => {
+            quote! { self }
+        }
+        ContextArg::Ident(_) => {
+            quote! { context }
+        }
+    };
+
+    let call_expr = match provider_ident {
+        Some(provider_ident) => {
+            quote! {
+                #provider_ident :: #get_field_method ( #context_var, ::core::marker::PhantomData #phantom_generics )
+            }
+        }
+        None => {
+            quote! {
+                #context_var . #get_field_method ( ::core::marker::PhantomData #phantom_generics )
+            }
+        }
+    };
+
+    quote! {
+        fn #field_name( #context_fn_arg #phantom_arg ) -> & #provider_type {
+            #call_expr
+        }
+    }
+}

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
 
-use crate::getter_component::GetterField;
+use crate::getter_component::{FieldMode, GetterField};
 
 pub enum ContextArg {
     SelfArg,
@@ -18,7 +18,7 @@ pub fn derive_getter_method(
     let field_name = &spec.field_name;
     let provider_type = &spec.provider_type;
 
-    let phantom_arg = match &spec.phantom {
+    let phantom_arg = match &spec.phantom_arg_type {
         Some(phantom) => {
             quote! {
                 , _phantom: #phantom
@@ -70,6 +70,16 @@ pub fn derive_getter_method(
                 #context_var . #get_field_method ( ::core::marker::PhantomData #phantom_generics )
             }
         }
+    };
+
+    let call_expr = match spec.field_mode {
+        FieldMode::Reference => call_expr,
+        FieldMode::AsRef => quote! {
+            #call_expr .as_ref()
+        },
+        FieldMode::Clone => quote! {
+            #call_expr .clone()
+        },
     };
 
     let return_type = if spec.field_mut.is_none() {

--- a/crates/cgp-component-macro-lib/src/getter_component/method.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/method.rs
@@ -20,7 +20,7 @@ pub fn derive_getter_method(
     let phantom_arg = match &spec.phantom_arg_type {
         Some(phantom) => {
             quote! {
-                , _phantom: #phantom
+                , _phantom: PhantomData< #phantom >
             }
         }
         None => TokenStream::new(),

--- a/crates/cgp-component-macro-lib/src/getter_component/mod.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/mod.rs
@@ -1,4 +1,5 @@
 mod blanket;
+mod constraint;
 mod getter_field;
 mod method;
 mod parse;
@@ -8,6 +9,7 @@ mod use_fields;
 mod with_provider;
 
 pub use blanket::*;
+pub use constraint::*;
 pub use getter_field::*;
 pub use method::*;
 pub use parse::*;

--- a/crates/cgp-component-macro-lib/src/getter_component/mod.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/mod.rs
@@ -1,5 +1,6 @@
 mod blanket;
 mod getter_field;
+mod method;
 mod parse;
 mod symbol;
 mod use_field;
@@ -8,6 +9,7 @@ mod with_provider;
 
 pub use blanket::*;
 pub use getter_field::*;
+pub use method::*;
 pub use parse::*;
 pub use use_field::*;
 pub use use_fields::*;

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -1,8 +1,11 @@
 use alloc::vec::Vec;
 
-use quote::{quote, ToTokens};
+use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{parse_quote, Error, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
+use syn::{
+    parse_quote, Error, FnArg, GenericArgument, Ident, ItemTrait, PathArguments, ReturnType,
+    TraitItem, Type, TypePath,
+};
 
 use crate::derive_component::replace_self_type;
 use crate::getter_component::getter_field::GetterField;
@@ -132,14 +135,24 @@ pub fn parse_getter_fields(
                                     ));
                                 }
 
-                                // if type_ref == &parse_quote! { &str } {
-                                // } else {
+                                if type_ref == &parse_quote! { &str } {
+                                    // Special case to handle &str as String field
 
-                                // }
+                                    let field_type: Type = parse_quote! { String };
 
-                                let field_type: Type = type_ref.elem.as_ref().clone();
+                                    (field_type, FieldMode::Str)
+                                } else {
+                                    let field_type: Type = type_ref.elem.as_ref().clone();
 
-                                (field_type, FieldMode::Reference)
+                                    (field_type, FieldMode::Reference)
+                                }
+                            }
+                            Type::Path(type_path) => {
+                                if try_parse_option_ref(type_path).is_some() {
+                                    (return_type, FieldMode::AsRef)
+                                } else {
+                                    (return_type, FieldMode::Clone)
+                                }
                             }
                             _ => {
                                 return Err(Error::new(
@@ -181,4 +194,20 @@ pub fn parse_getter_fields(
     }
 
     Ok(fields)
+}
+
+pub fn try_parse_option_ref(type_path: &TypePath) -> Option<&Type> {
+    let m_segment = type_path.path.segments.iter().next();
+
+    if let Some(segment) = m_segment {
+        if segment.ident == "Option" {
+            if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                if let Some(GenericArgument::Type(Type::Reference(type_ref))) = args.args.first() {
+                    return Some(type_ref.elem.as_ref());
+                }
+            }
+        }
+    }
+
+    None
 }

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -2,10 +2,11 @@ use alloc::vec::Vec;
 
 use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{parse_quote, Error, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
+use syn::{parse2, parse_quote, Error, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
 
 use crate::derive_component::replace_self_type;
 use crate::getter_component::getter_field::GetterField;
+use crate::parse::SimpleType;
 
 pub fn parse_getter_fields(
     context_type: &Ident,
@@ -55,17 +56,51 @@ pub fn parse_getter_fields(
 
                 let field_name = signature.ident.clone();
 
-                let [arg]: [&FnArg; 1] = signature
-                    .inputs
-                    .iter()
-                    .collect::<Vec<&FnArg>>()
-                    .try_into()
-                    .map_err(|_| {
-                        Error::new(
+                let args_count = signature.inputs.len();
+
+                let (arg, phantom) = if args_count == 1 {
+                    let [arg]: [&FnArg; 1] = signature
+                        .inputs
+                        .iter()
+                        .collect::<Vec<&FnArg>>()
+                        .try_into()
+                        .map_err(|_| {
+                            Error::new(
+                                signature.inputs.span(),
+                                "getter method must contain exactly one `&self` argument",
+                            )
+                        })?;
+
+                    (arg, None)
+                } else if args_count == 2 {
+                    let [arg, phantom]: [&FnArg; 2] = signature
+                        .inputs
+                        .iter()
+                        .collect::<Vec<&FnArg>>()
+                        .try_into()
+                        .map_err(|_| {
+                            Error::new(
+                                signature.inputs.span(),
+                                "getter method must contain exactly one `&self` argument",
+                            )
+                        })?;
+
+                    let phantom: SimpleType = parse2(phantom.to_token_stream())?;
+
+                    if phantom.name != "PhantomData" {
+                        return Err(Error::new(
                             signature.inputs.span(),
-                            "getter method must contain exactly one `&self` argument",
-                        )
-                    })?;
+                            "optional second argument in getter must be PhantomData",
+                        ));
+                    }
+
+                    (arg, Some(phantom))
+                } else {
+                    return Err(Error::new(
+                        signature.inputs.span(),
+                        "getter method must contain exactly one `&self` argument",
+                    ));
+                };
 
                 let field_mut = match arg {
                     FnArg::Receiver(receiver) => {
@@ -121,6 +156,7 @@ pub fn parse_getter_fields(
                     field_name,
                     provider_type,
                     field_mut,
+                    phantom,
                 })
             }
             _ => {

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -1,10 +1,10 @@
 use alloc::vec::Vec;
 
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
 use syn::{
-    parse_quote, Error, FnArg, GenericArgument, Ident, ItemTrait, PathArguments, ReturnType,
-    TraitItem, Type, TypePath,
+    parse2, parse_quote, Error, FnArg, GenericArgument, Ident, ItemTrait, PathArguments,
+    ReturnType, TraitItem, Type, TypePath,
 };
 
 use crate::derive_component::replace_self_type;
@@ -123,45 +123,12 @@ pub fn parse_getter_fields(
                     }
                 };
 
-                let (field_type, field_mode) = match &signature.output {
-                    ReturnType::Type(_, ty) => {
-                        let return_type = ty.as_ref().clone();
-                        match &return_type {
-                            Type::Reference(type_ref) => {
-                                if type_ref.mutability.is_some() != field_mut.is_some() {
-                                    return Err(Error::new(
-                                        type_ref.span(),
-                                        "return type have the same mutability as the self reference",
-                                    ));
-                                }
-
-                                if type_ref == &parse_quote! { &str } {
-                                    // Special case to handle &str as String field
-
-                                    let field_type: Type = parse_quote! { String };
-
-                                    (field_type, FieldMode::Str)
-                                } else {
-                                    let field_type: Type = type_ref.elem.as_ref().clone();
-
-                                    (field_type, FieldMode::Reference)
-                                }
-                            }
-                            Type::Path(type_path) => {
-                                if try_parse_option_ref(type_path).is_some() {
-                                    (return_type, FieldMode::AsRef)
-                                } else {
-                                    (return_type, FieldMode::Clone)
-                                }
-                            }
-                            _ => {
-                                return Err(Error::new(
-                                    return_type.span(),
-                                    "return type must be a reference",
-                                ))
-                            }
-                        }
-                    }
+                let return_type = match &signature.output {
+                    ReturnType::Type(_, ty) => parse2(replace_self_type(
+                        ty.to_token_stream(),
+                        context_type,
+                        &Vec::new(),
+                    ))?,
                     _ => {
                         return Err(Error::new(
                             signature.span(),
@@ -170,15 +137,49 @@ pub fn parse_getter_fields(
                     }
                 };
 
-                let provider_type: Type = syn::parse2(replace_self_type(
-                    field_type.to_token_stream(),
-                    context_type,
-                    &Vec::new(),
-                ))?;
+                let (field_type, field_mode) = match &return_type {
+                    Type::Reference(type_ref) => {
+                        if type_ref.mutability.is_some() != field_mut.is_some() {
+                            return Err(Error::new(
+                                type_ref.span(),
+                                "return type have the same mutability as the self reference",
+                            ));
+                        }
+
+                        if type_ref == &parse_quote! { &str } {
+                            // Special case to handle &str as String field
+
+                            let field_type: Type = parse_quote! { String };
+
+                            (field_type, FieldMode::Str)
+                        } else {
+                            let field_type: Type = type_ref.elem.as_ref().clone();
+
+                            (field_type, FieldMode::Reference)
+                        }
+                    }
+                    Type::Path(type_path) => {
+                        if let Some(field_type) = try_parse_option_ref(type_path) {
+                            (
+                                parse2(quote! { Option< #field_type > })?,
+                                FieldMode::OptionRef,
+                            )
+                        } else {
+                            (return_type.clone(), FieldMode::Clone)
+                        }
+                    }
+                    _ => {
+                        return Err(Error::new(
+                            return_type.span(),
+                            "return type must be a reference",
+                        ))
+                    }
+                };
 
                 fields.push(GetterField {
                     field_name,
-                    provider_type,
+                    field_type,
+                    return_type,
                     field_mut,
                     phantom_arg_type: phantom,
                     field_mode,

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -6,7 +6,7 @@ use syn::spanned::Spanned;
 use syn::token::{Comma, Mut};
 use syn::{
     parse2, parse_quote, Error, FnArg, GenericArgument, Ident, ItemTrait, PathArguments,
-    ReturnType, Signature, TraitItem, TraitItemFn, Type, TypePath,
+    PathSegment, ReturnType, Signature, TraitItem, TraitItemFn, Type, TypePath,
 };
 
 use crate::derive_component::replace_self_type;
@@ -135,12 +135,16 @@ fn parse_fixed_size_args<const I: usize>(
 fn parse_phantom_arg_type(phantom_arg: &FnArg) -> syn::Result<Type> {
     match phantom_arg {
         FnArg::Typed(phantom_type) => match phantom_type.ty.as_ref() {
-            Type::Path(type_path) => try_parse_phantom_arg_type_path(type_path).ok_or_else(|| {
-                Error::new(
-                    phantom_type.span(),
-                    "only PhantomData is allowed as second argument",
-                )
-            }),
+            Type::Path(type_path) => {
+                let segment = parse_single_segment_type_path(type_path)?;
+
+                try_parse_phantom_arg_type_path(segment).ok_or_else(|| {
+                    Error::new(
+                        phantom_type.span(),
+                        "only PhantomData is allowed as second argument",
+                    )
+                })
+            }
             _ => {
                 return Err(Error::new(
                     phantom_type.span(),
@@ -227,9 +231,24 @@ fn parse_field_type(return_type: &Type, field_mut: &Option<Mut>) -> syn::Result<
     }
 }
 
-fn try_parse_phantom_arg_type_path(type_path: &TypePath) -> Option<Type> {
-    let segment = type_path.path.segments.iter().next()?;
+fn parse_single_segment_type_path(type_path: &TypePath) -> syn::Result<&PathSegment> {
+    let [segment]: [&PathSegment; 1] = type_path
+        .path
+        .segments
+        .iter()
+        .collect::<Vec<_>>()
+        .try_into()
+        .map_err(|_| {
+            Error::new(
+                type_path.span(),
+                "type path must contain exactly one path segment",
+            )
+        })?;
 
+    Ok(segment)
+}
+
+fn try_parse_phantom_arg_type_path(segment: &PathSegment) -> Option<Type> {
     if segment.ident == "PhantomData" {
         if let PathArguments::AngleBracketed(args) = &segment.arguments {
             if let Some(GenericArgument::Type(ty)) = args.args.first() {
@@ -242,14 +261,12 @@ fn try_parse_phantom_arg_type_path(type_path: &TypePath) -> Option<Type> {
 }
 
 fn try_parse_option_ref(type_path: &TypePath) -> Option<&Type> {
-    let m_segment = type_path.path.segments.iter().next();
+    let segment = parse_single_segment_type_path(type_path).ok()?;
 
-    if let Some(segment) = m_segment {
-        if segment.ident == "Option" {
-            if let PathArguments::AngleBracketed(args) = &segment.arguments {
-                if let Some(GenericArgument::Type(Type::Reference(type_ref))) = args.args.first() {
-                    return Some(type_ref.elem.as_ref());
-                }
+    if segment.ident == "Option" {
+        if let PathArguments::AngleBracketed(args) = &segment.arguments {
+            if let Some(GenericArgument::Type(Type::Reference(type_ref))) = args.args.first() {
+                return Some(type_ref.elem.as_ref());
             }
         }
     }

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -145,12 +145,10 @@ fn parse_phantom_arg_type(phantom_arg: &FnArg) -> syn::Result<Type> {
                     )
                 })
             }
-            _ => {
-                return Err(Error::new(
-                    phantom_type.span(),
-                    "only PhantomData is allowed as second argument",
-                ));
-            }
+            _ => Err(Error::new(
+                phantom_type.span(),
+                "only PhantomData is allowed as second argument",
+            )),
         },
         _ => Err(Error::new(
             phantom_arg.span(),

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -96,7 +96,7 @@ pub fn parse_getter_fields(
                                 ));
                             }
 
-                            (arg, None)
+                            (arg, Some(phantom))
                         }
                         _ => {
                             return Err(Error::new(

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -73,7 +73,7 @@ pub fn parse_getter_fields(
 
                     (arg, None)
                 } else if args_count == 2 {
-                    let [arg, phantom]: [&FnArg; 2] = signature
+                    let [arg, phantom_arg]: [&FnArg; 2] = signature
                         .inputs
                         .iter()
                         .collect::<Vec<&FnArg>>()
@@ -85,16 +85,26 @@ pub fn parse_getter_fields(
                             )
                         })?;
 
-                    let phantom: SimpleType = parse2(phantom.to_token_stream())?;
+                    match phantom_arg {
+                        FnArg::Typed(phantom_type) => {
+                            let phantom: SimpleType = parse2(phantom_type.ty.to_token_stream())?;
 
-                    if phantom.name != "PhantomData" {
-                        return Err(Error::new(
-                            signature.inputs.span(),
-                            "optional second argument in getter must be PhantomData",
-                        ));
+                            if phantom.name != "PhantomData" {
+                                return Err(Error::new(
+                                    signature.inputs.span(),
+                                    "optional second argument in getter must be PhantomData",
+                                ));
+                            }
+
+                            (arg, None)
+                        }
+                        _ => {
+                            return Err(Error::new(
+                                signature.inputs.span(),
+                                "optional second argument in getter must be PhantomData",
+                            ));
+                        }
                     }
-
-                    (arg, Some(phantom))
                 } else {
                     return Err(Error::new(
                         signature.inputs.span(),

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -146,7 +146,7 @@ pub fn parse_getter_fields(
                             ));
                         }
 
-                        if type_ref == &parse_quote! { &str } {
+                        if type_ref.elem.as_ref() == &parse_quote! { str } {
                             // Special case to handle &str as String field
 
                             let field_type: Type = parse_quote! { String };

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -134,13 +134,24 @@ fn parse_fixed_size_args<const I: usize>(
 
 fn parse_phantom_arg_type(phantom_arg: &FnArg) -> syn::Result<Type> {
     match phantom_arg {
-        FnArg::Typed(phantom_type) => Ok(phantom_type.ty.as_ref().clone()),
-        _ => {
-            return Err(Error::new(
-                phantom_arg.span(),
-                "optional second argument in getter must be PhantomData",
-            ));
-        }
+        FnArg::Typed(phantom_type) => match phantom_type.ty.as_ref() {
+            Type::Path(type_path) => try_parse_phantom_arg_type_path(type_path).ok_or_else(|| {
+                Error::new(
+                    phantom_type.span(),
+                    "only PhantomData is allowed as second argument",
+                )
+            }),
+            _ => {
+                return Err(Error::new(
+                    phantom_type.span(),
+                    "only PhantomData is allowed as second argument",
+                ));
+            }
+        },
+        _ => Err(Error::new(
+            phantom_arg.span(),
+            "optional second argument in getter must be PhantomData",
+        )),
     }
 }
 
@@ -148,20 +159,18 @@ fn parse_field_mut(arg: &FnArg) -> syn::Result<Option<Mut>> {
     match arg {
         FnArg::Receiver(receiver) => {
             if receiver.reference.is_none() {
-                return Err(Error::new(
+                Err(Error::new(
                     receiver.span(),
                     "first argument to getter method must be a reference to self, i.e. `&self`",
-                ));
+                ))
+            } else {
+                Ok(receiver.mutability)
             }
-
-            Ok(receiver.mutability)
         }
-        _ => {
-            return Err(Error::new(
-                arg.span(),
-                "first argument to getter method must be `&self`",
-            ))
-        }
+        _ => Err(Error::new(
+            arg.span(),
+            "first argument to getter method must be `&self`",
+        )),
     }
 }
 
@@ -216,6 +225,20 @@ fn parse_field_type(return_type: &Type, field_mut: &Option<Mut>) -> syn::Result<
             "return type must be a reference",
         )),
     }
+}
+
+fn try_parse_phantom_arg_type_path(type_path: &TypePath) -> Option<Type> {
+    let segment = type_path.path.segments.iter().next()?;
+
+    if segment.ident == "PhantomData" {
+        if let PathArguments::AngleBracketed(args) = &segment.arguments {
+            if let Some(GenericArgument::Type(ty)) = args.args.first() {
+                return Some(ty.clone());
+            }
+        }
+    }
+
+    None
 }
 
 fn try_parse_option_ref(type_path: &TypePath) -> Option<&Type> {

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -2,11 +2,10 @@ use alloc::vec::Vec;
 
 use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{parse2, parse_quote, Error, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
+use syn::{parse_quote, Error, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
 
 use crate::derive_component::replace_self_type;
 use crate::getter_component::getter_field::GetterField;
-use crate::parse::SimpleType;
 
 pub fn parse_getter_fields(
     context_type: &Ident,
@@ -86,18 +85,7 @@ pub fn parse_getter_fields(
                         })?;
 
                     match phantom_arg {
-                        FnArg::Typed(phantom_type) => {
-                            let phantom: SimpleType = parse2(phantom_type.ty.to_token_stream())?;
-
-                            if phantom.name != "PhantomData" {
-                                return Err(Error::new(
-                                    signature.inputs.span(),
-                                    "optional second argument in getter must be PhantomData",
-                                ));
-                            }
-
-                            (arg, Some(phantom))
-                        }
+                        FnArg::Typed(phantom_type) => (arg, Some(phantom_type.ty.as_ref().clone())),
                         _ => {
                             return Err(Error::new(
                                 signature.inputs.span(),

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -1,11 +1,12 @@
 use alloc::vec::Vec;
 
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
 use syn::{parse_quote, Error, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
 
 use crate::derive_component::replace_self_type;
 use crate::getter_component::getter_field::GetterField;
+use crate::getter_component::FieldMode;
 
 pub fn parse_getter_fields(
     context_type: &Ident,
@@ -119,11 +120,10 @@ pub fn parse_getter_fields(
                     }
                 };
 
-                let field_type: Type = match &signature.output {
-                    ReturnType::Default => parse_quote!(()),
+                let (field_type, field_mode) = match &signature.output {
                     ReturnType::Type(_, ty) => {
-                        let ty = ty.as_ref().clone();
-                        match &ty {
+                        let return_type = ty.as_ref().clone();
+                        match &return_type {
                             Type::Reference(type_ref) => {
                                 if type_ref.mutability.is_some() != field_mut.is_some() {
                                     return Err(Error::new(
@@ -132,15 +132,28 @@ pub fn parse_getter_fields(
                                     ));
                                 }
 
-                                type_ref.elem.as_ref().clone()
+                                // if type_ref == &parse_quote! { &str } {
+                                // } else {
+
+                                // }
+
+                                let field_type: Type = type_ref.elem.as_ref().clone();
+
+                                (field_type, FieldMode::Reference)
                             }
                             _ => {
                                 return Err(Error::new(
-                                    ty.span(),
+                                    return_type.span(),
                                     "return type must be a reference",
                                 ))
                             }
                         }
+                    }
+                    _ => {
+                        return Err(Error::new(
+                            signature.span(),
+                            "return type must be specified",
+                        ))
                     }
                 };
 
@@ -154,7 +167,8 @@ pub fn parse_getter_fields(
                     field_name,
                     provider_type,
                     field_mut,
-                    phantom,
+                    phantom_arg_type: phantom,
+                    field_mode,
                 })
             }
             _ => {

--- a/crates/cgp-component-macro-lib/src/getter_component/parse.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/parse.rs
@@ -1,10 +1,12 @@
 use alloc::vec::Vec;
 
 use quote::{quote, ToTokens};
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
+use syn::token::{Comma, Mut};
 use syn::{
     parse2, parse_quote, Error, FnArg, GenericArgument, Ident, ItemTrait, PathArguments,
-    ReturnType, TraitItem, Type, TypePath,
+    ReturnType, Signature, TraitItem, TraitItemFn, Type, TypePath,
 };
 
 use crate::derive_component::replace_self_type;
@@ -20,170 +22,9 @@ pub fn parse_getter_fields(
     for item in consumer_trait.items.iter() {
         match item {
             TraitItem::Fn(method) => {
-                let signature = &method.sig;
+                let getter_spec = parse_getter_method(context_type, method)?;
 
-                if signature.constness.is_some() {
-                    return Err(Error::new(
-                        signature.constness.span(),
-                        "getter method must not be const fn",
-                    ));
-                }
-
-                if signature.asyncness.is_some() {
-                    return Err(Error::new(
-                        signature.asyncness.span(),
-                        "getter method must not be async fn",
-                    ));
-                }
-
-                if signature.unsafety.is_some() {
-                    return Err(Error::new(
-                        signature.unsafety.span(),
-                        "getter method must not be unsafe fn",
-                    ));
-                }
-
-                if !signature.generics.params.is_empty() {
-                    return Err(Error::new(
-                        signature.generics.params.span(),
-                        "getter method must not contain generic param",
-                    ));
-                }
-
-                if signature.generics.where_clause.is_some() {
-                    return Err(Error::new(
-                        signature.generics.where_clause.span(),
-                        "getter method must not contain where clause",
-                    ));
-                }
-
-                let field_name = signature.ident.clone();
-
-                let args_count = signature.inputs.len();
-
-                let (arg, phantom) = if args_count == 1 {
-                    let [arg]: [&FnArg; 1] = signature
-                        .inputs
-                        .iter()
-                        .collect::<Vec<&FnArg>>()
-                        .try_into()
-                        .map_err(|_| {
-                            Error::new(
-                                signature.inputs.span(),
-                                "getter method must contain exactly one `&self` argument",
-                            )
-                        })?;
-
-                    (arg, None)
-                } else if args_count == 2 {
-                    let [arg, phantom_arg]: [&FnArg; 2] = signature
-                        .inputs
-                        .iter()
-                        .collect::<Vec<&FnArg>>()
-                        .try_into()
-                        .map_err(|_| {
-                            Error::new(
-                                signature.inputs.span(),
-                                "getter method must contain exactly one `&self` argument",
-                            )
-                        })?;
-
-                    match phantom_arg {
-                        FnArg::Typed(phantom_type) => (arg, Some(phantom_type.ty.as_ref().clone())),
-                        _ => {
-                            return Err(Error::new(
-                                signature.inputs.span(),
-                                "optional second argument in getter must be PhantomData",
-                            ));
-                        }
-                    }
-                } else {
-                    return Err(Error::new(
-                        signature.inputs.span(),
-                        "getter method must contain exactly one `&self` argument",
-                    ));
-                };
-
-                let field_mut = match arg {
-                    FnArg::Receiver(receiver) => {
-                        if receiver.reference.is_none() {
-                            return Err(Error::new(
-                                receiver.span(),
-                                "first argument to getter method must be a reference to self, i.e. `&self`"
-                            ));
-                        }
-
-                        receiver.mutability
-                    }
-                    _ => {
-                        return Err(Error::new(
-                            arg.span(),
-                            "first argument to getter method must be `&self`",
-                        ))
-                    }
-                };
-
-                let return_type = match &signature.output {
-                    ReturnType::Type(_, ty) => parse2(replace_self_type(
-                        ty.to_token_stream(),
-                        context_type,
-                        &Vec::new(),
-                    ))?,
-                    _ => {
-                        return Err(Error::new(
-                            signature.span(),
-                            "return type must be specified",
-                        ))
-                    }
-                };
-
-                let (field_type, field_mode) = match &return_type {
-                    Type::Reference(type_ref) => {
-                        if type_ref.mutability.is_some() != field_mut.is_some() {
-                            return Err(Error::new(
-                                type_ref.span(),
-                                "return type have the same mutability as the self reference",
-                            ));
-                        }
-
-                        if type_ref.elem.as_ref() == &parse_quote! { str } {
-                            // Special case to handle &str as String field
-
-                            let field_type: Type = parse_quote! { String };
-
-                            (field_type, FieldMode::Str)
-                        } else {
-                            let field_type: Type = type_ref.elem.as_ref().clone();
-
-                            (field_type, FieldMode::Reference)
-                        }
-                    }
-                    Type::Path(type_path) => {
-                        if let Some(field_type) = try_parse_option_ref(type_path) {
-                            (
-                                parse2(quote! { Option< #field_type > })?,
-                                FieldMode::OptionRef,
-                            )
-                        } else {
-                            (return_type.clone(), FieldMode::Clone)
-                        }
-                    }
-                    _ => {
-                        return Err(Error::new(
-                            return_type.span(),
-                            "return type must be a reference",
-                        ))
-                    }
-                };
-
-                fields.push(GetterField {
-                    field_name,
-                    field_type,
-                    return_type,
-                    field_mut,
-                    phantom_arg_type: phantom,
-                    field_mode,
-                })
+                fields.push(getter_spec);
             }
             _ => {
                 return Err(Error::new(
@@ -197,7 +38,187 @@ pub fn parse_getter_fields(
     Ok(fields)
 }
 
-pub fn try_parse_option_ref(type_path: &TypePath) -> Option<&Type> {
+fn parse_getter_method(context_type: &Ident, method: &TraitItemFn) -> syn::Result<GetterField> {
+    let signature = &method.sig;
+
+    validate_getter_method_signature(signature)?;
+
+    let field_name = signature.ident.clone();
+
+    let (arg, phantom) = parse_method_args(&signature.inputs)?;
+
+    let field_mut = parse_field_mut(arg)?;
+
+    let return_type = parse_return_type(context_type, &signature.output)?;
+
+    let (field_type, field_mode) = parse_field_type(&return_type, &field_mut)?;
+
+    Ok(GetterField {
+        field_name,
+        field_type,
+        return_type,
+        field_mut,
+        phantom_arg_type: phantom,
+        field_mode,
+    })
+}
+
+pub fn validate_getter_method_signature(signature: &Signature) -> syn::Result<()> {
+    if signature.constness.is_some() {
+        return Err(Error::new(
+            signature.constness.span(),
+            "getter method must not be const fn",
+        ));
+    }
+
+    if signature.asyncness.is_some() {
+        return Err(Error::new(
+            signature.asyncness.span(),
+            "getter method must not be async fn",
+        ));
+    }
+
+    if signature.unsafety.is_some() {
+        return Err(Error::new(
+            signature.unsafety.span(),
+            "getter method must not be unsafe fn",
+        ));
+    }
+
+    if !signature.generics.params.is_empty() {
+        return Err(Error::new(
+            signature.generics.params.span(),
+            "getter method must not contain generic param",
+        ));
+    }
+
+    if signature.generics.where_clause.is_some() {
+        return Err(Error::new(
+            signature.generics.where_clause.span(),
+            "getter method must not contain where clause",
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_method_args(args: &Punctuated<FnArg, Comma>) -> syn::Result<(&FnArg, Option<Type>)> {
+    let args_count = args.len();
+
+    if args_count == 1 {
+        let [arg] = parse_fixed_size_args::<1>(args)?;
+
+        Ok((arg, None))
+    } else if args_count == 2 {
+        let [arg, phantom_arg] = parse_fixed_size_args::<2>(args)?;
+
+        let phantom_arg_type = parse_phantom_arg_type(phantom_arg)?;
+
+        Ok((arg, Some(phantom_arg_type)))
+    } else {
+        return Err(Error::new(
+            args.span(),
+            "getter method must contain exactly one `&self` argument",
+        ));
+    }
+}
+
+fn parse_fixed_size_args<const I: usize>(
+    args: &Punctuated<FnArg, Comma>,
+) -> syn::Result<[&FnArg; I]> {
+    args.iter()
+        .collect::<Vec<&FnArg>>()
+        .try_into()
+        .map_err(|_| Error::new(args.span(), "expect getter method to contain {I} arguments"))
+}
+
+fn parse_phantom_arg_type(phantom_arg: &FnArg) -> syn::Result<Type> {
+    match phantom_arg {
+        FnArg::Typed(phantom_type) => Ok(phantom_type.ty.as_ref().clone()),
+        _ => {
+            return Err(Error::new(
+                phantom_arg.span(),
+                "optional second argument in getter must be PhantomData",
+            ));
+        }
+    }
+}
+
+fn parse_field_mut(arg: &FnArg) -> syn::Result<Option<Mut>> {
+    match arg {
+        FnArg::Receiver(receiver) => {
+            if receiver.reference.is_none() {
+                return Err(Error::new(
+                    receiver.span(),
+                    "first argument to getter method must be a reference to self, i.e. `&self`",
+                ));
+            }
+
+            Ok(receiver.mutability)
+        }
+        _ => {
+            return Err(Error::new(
+                arg.span(),
+                "first argument to getter method must be `&self`",
+            ))
+        }
+    }
+}
+
+fn parse_return_type(context_type: &Ident, return_type: &ReturnType) -> syn::Result<Type> {
+    match return_type {
+        ReturnType::Type(_, ty) => parse2(replace_self_type(
+            ty.to_token_stream(),
+            context_type,
+            &Vec::new(),
+        )),
+        _ => Err(Error::new(
+            return_type.span(),
+            "return type must be specified",
+        )),
+    }
+}
+
+fn parse_field_type(return_type: &Type, field_mut: &Option<Mut>) -> syn::Result<(Type, FieldMode)> {
+    match &return_type {
+        Type::Reference(type_ref) => {
+            if type_ref.mutability.is_some() != field_mut.is_some() {
+                return Err(Error::new(
+                    type_ref.span(),
+                    "return type have the same mutability as the self reference",
+                ));
+            }
+
+            if type_ref.elem.as_ref() == &parse_quote! { str } {
+                // Special case to handle &str as String field
+
+                let field_type: Type = parse_quote! { String };
+
+                Ok((field_type, FieldMode::Str))
+            } else {
+                let field_type: Type = type_ref.elem.as_ref().clone();
+
+                Ok((field_type, FieldMode::Reference))
+            }
+        }
+        Type::Path(type_path) => {
+            if let Some(field_type) = try_parse_option_ref(type_path) {
+                Ok((
+                    parse2(quote! { Option< #field_type > })?,
+                    FieldMode::OptionRef,
+                ))
+            } else {
+                Ok((return_type.clone(), FieldMode::Clone))
+            }
+        }
+        _ => Err(Error::new(
+            return_type.span(),
+            "return type must be a reference",
+        )),
+    }
+}
+
+fn try_parse_option_ref(type_path: &TypePath) -> Option<&Type> {
     let m_segment = type_path.path.segments.iter().next();
 
     if let Some(segment) = m_segment {

--- a/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
@@ -1,10 +1,10 @@
-use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::Plus;
 use syn::{parse2, Generics, ItemImpl, ItemTrait, TypeParamBound};
 
 use crate::getter_component::getter_field::GetterField;
+use crate::getter_component::{derive_getter_method, ContextArg};
 use crate::parse::ComponentSpec;
 
 pub fn derive_use_field_impl(
@@ -17,40 +17,20 @@ pub fn derive_use_field_impl(
 
     let mut field_constraints: Punctuated<TypeParamBound, Plus> = Punctuated::default();
 
-    let field_name = &field.field_name;
     let provider_type = &field.provider_type;
 
     let tag_type = quote! { __Tag__ };
 
-    let phantom_arg = match &field.phantom {
-        Some(phantom) => {
-            quote! {
-                , _phantom: #phantom
-            }
-        }
-        None => TokenStream::new(),
-    };
+    let method = derive_getter_method(&ContextArg::Ident(context_type.clone()), field, None, None);
 
-    let method = if field.field_mut.is_none() {
+    if field.field_mut.is_none() {
         field_constraints.push(parse2(quote! {
             HasField< #tag_type, Value = #provider_type >
         })?);
-
-        quote! {
-            fn #field_name( context: & #context_type #phantom_arg ) -> & #provider_type {
-                context.get_field( ::core::marker::PhantomData )
-            }
-        }
     } else {
         field_constraints.push(parse2(quote! {
             HasFieldMut< #tag_type, Value = #provider_type >
         })?);
-
-        quote! {
-            fn #field_name( context: &mut #context_type #phantom_arg ) -> &mut #provider_type {
-                context.get_field_mut( ::core::marker::PhantomData )
-            }
-        }
     };
 
     let mut provider_generics = provider_trait.generics.clone();

--- a/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
@@ -1,3 +1,4 @@
+use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::Plus;
@@ -21,13 +22,22 @@ pub fn derive_use_field_impl(
 
     let tag_type = quote! { __Tag__ };
 
+    let phantom_arg = match &field.phantom {
+        Some(phantom) => {
+            quote! {
+                , _phantom: #phantom
+            }
+        }
+        None => TokenStream::new(),
+    };
+
     let method = if field.field_mut.is_none() {
         field_constraints.push(parse2(quote! {
             HasField< #tag_type, Value = #provider_type >
         })?);
 
         quote! {
-            fn #field_name( context: & #context_type ) -> & #provider_type {
+            fn #field_name( context: & #context_type #phantom_arg ) -> & #provider_type {
                 context.get_field( ::core::marker::PhantomData )
             }
         }
@@ -37,7 +47,7 @@ pub fn derive_use_field_impl(
         })?);
 
         quote! {
-            fn #field_name( context: &mut #context_type ) -> &mut #provider_type {
+            fn #field_name( context: &mut #context_type #phantom_arg ) -> &mut #provider_type {
                 context.get_field_mut( ::core::marker::PhantomData )
             }
         }

--- a/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_field.rs
@@ -4,7 +4,7 @@ use syn::token::Plus;
 use syn::{parse2, Generics, ItemImpl, ItemTrait, TypeParamBound};
 
 use crate::getter_component::getter_field::GetterField;
-use crate::getter_component::{derive_getter_method, ContextArg};
+use crate::getter_component::{derive_getter_constraint, derive_getter_method, ContextArg};
 use crate::parse::ComponentSpec;
 
 pub fn derive_use_field_impl(
@@ -17,21 +17,13 @@ pub fn derive_use_field_impl(
 
     let mut field_constraints: Punctuated<TypeParamBound, Plus> = Punctuated::default();
 
-    let provider_type = &field.provider_type;
-
     let tag_type = quote! { __Tag__ };
 
     let method = derive_getter_method(&ContextArg::Ident(context_type.clone()), field, None, None);
 
-    if field.field_mut.is_none() {
-        field_constraints.push(parse2(quote! {
-            HasField< #tag_type, Value = #provider_type >
-        })?);
-    } else {
-        field_constraints.push(parse2(quote! {
-            HasFieldMut< #tag_type, Value = #provider_type >
-        })?);
-    };
+    let constraint = derive_getter_constraint(field, quote! { #tag_type })?;
+
+    field_constraints.push(constraint);
 
     let mut provider_generics = provider_trait.generics.clone();
 

--- a/crates/cgp-component-macro-lib/src/getter_component/use_fields.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_fields.rs
@@ -8,6 +8,7 @@ use syn::{parse2, ItemImpl, ItemTrait, TypeParamBound};
 
 use crate::getter_component::getter_field::GetterField;
 use crate::getter_component::symbol::symbol_from_string;
+use crate::getter_component::{derive_getter_method, ContextArg};
 use crate::parse::ComponentSpec;
 
 pub fn derive_use_fields_impl(
@@ -24,39 +25,25 @@ pub fn derive_use_fields_impl(
     let mut methods: TokenStream = TokenStream::new();
 
     for field in fields {
-        let field_name = &field.field_name;
         let provider_type = &field.provider_type;
         let field_symbol = symbol_from_string(&field.field_name.to_string());
 
-        let phantom_arg = match &field.phantom {
-            Some(phantom) => {
-                quote! {
-                    , _phantom: #phantom
-                }
-            }
-            None => TokenStream::new(),
-        };
+        let method = derive_getter_method(
+            &ContextArg::Ident(context_type.clone()),
+            field,
+            Some(quote! { ::< #field_symbol > }),
+            None,
+        );
+        methods.extend(method);
 
         if field.field_mut.is_none() {
             field_constraints.push(parse2(quote! {
                 HasField< #field_symbol, Value = #provider_type >
             })?);
-
-            methods.extend(quote! {
-                fn #field_name( context: & #context_type #phantom_arg ) -> & #provider_type {
-                    context.get_field( ::core::marker::PhantomData::< #field_symbol > )
-                }
-            });
         } else {
             field_constraints.push(parse2(quote! {
                 HasFieldMut< #field_symbol, Value = #provider_type >
             })?);
-
-            methods.extend(quote! {
-                fn #field_name( context: &mut #context_type #phantom_arg ) -> &mut #provider_type {
-                    context.get_field_mut( ::core::marker::PhantomData::< #field_symbol > )
-                }
-            });
         }
     }
 

--- a/crates/cgp-component-macro-lib/src/getter_component/use_fields.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_fields.rs
@@ -8,7 +8,7 @@ use syn::{parse2, ItemImpl, ItemTrait, TypeParamBound};
 
 use crate::getter_component::getter_field::GetterField;
 use crate::getter_component::symbol::symbol_from_string;
-use crate::getter_component::{derive_getter_method, ContextArg};
+use crate::getter_component::{derive_getter_constraint, derive_getter_method, ContextArg};
 use crate::parse::ComponentSpec;
 
 pub fn derive_use_fields_impl(
@@ -25,7 +25,6 @@ pub fn derive_use_fields_impl(
     let mut methods: TokenStream = TokenStream::new();
 
     for field in fields {
-        let provider_type = &field.provider_type;
         let field_symbol = symbol_from_string(&field.field_name.to_string());
 
         let method = derive_getter_method(
@@ -34,17 +33,12 @@ pub fn derive_use_fields_impl(
             Some(quote! { ::< #field_symbol > }),
             None,
         );
+
         methods.extend(method);
 
-        if field.field_mut.is_none() {
-            field_constraints.push(parse2(quote! {
-                HasField< #field_symbol, Value = #provider_type >
-            })?);
-        } else {
-            field_constraints.push(parse2(quote! {
-                HasFieldMut< #field_symbol, Value = #provider_type >
-            })?);
-        }
+        let constraint = derive_getter_constraint(field, quote! { #field_symbol })?;
+
+        field_constraints.push(constraint);
     }
 
     let mut provider_generics = provider_trait.generics.clone();

--- a/crates/cgp-component-macro-lib/src/getter_component/use_fields.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/use_fields.rs
@@ -28,13 +28,22 @@ pub fn derive_use_fields_impl(
         let provider_type = &field.provider_type;
         let field_symbol = symbol_from_string(&field.field_name.to_string());
 
+        let phantom_arg = match &field.phantom {
+            Some(phantom) => {
+                quote! {
+                    , _phantom: #phantom
+                }
+            }
+            None => TokenStream::new(),
+        };
+
         if field.field_mut.is_none() {
             field_constraints.push(parse2(quote! {
                 HasField< #field_symbol, Value = #provider_type >
             })?);
 
             methods.extend(quote! {
-                fn #field_name( context: & #context_type ) -> & #provider_type {
+                fn #field_name( context: & #context_type #phantom_arg ) -> & #provider_type {
                     context.get_field( ::core::marker::PhantomData::< #field_symbol > )
                 }
             });
@@ -44,7 +53,7 @@ pub fn derive_use_fields_impl(
             })?);
 
             methods.extend(quote! {
-                fn #field_name( context: &mut #context_type ) -> &mut #provider_type {
+                fn #field_name( context: &mut #context_type #phantom_arg ) -> &mut #provider_type {
                     context.get_field_mut( ::core::marker::PhantomData::< #field_symbol > )
                 }
             });

--- a/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
@@ -21,13 +21,15 @@ pub fn derive_with_provider_impl(
 
     let provider_ident = Ident::new("__Provider__", Span::call_site());
 
+    let component_type = quote! { #component_name < #component_params > };
+
     let provider_constraint = if field.field_mut.is_none() {
         quote! {
-            FieldGetter< #context_type, #component_name < #component_params > , Value = #provider_type >
+            FieldGetter< #context_type, #component_type , Value = #provider_type >
         }
     } else {
         quote! {
-            MutFieldGetter< #context_type, #component_name < #component_params >, Value = #provider_type >
+            MutFieldGetter< #context_type, #component_type, Value = #provider_type >
         }
     };
 

--- a/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
@@ -1,8 +1,9 @@
-use proc_macro2::TokenStream;
+use proc_macro2::Span;
 use quote::{quote, ToTokens};
-use syn::{parse2, Generics, ItemImpl, ItemTrait};
+use syn::{parse2, Generics, Ident, ItemImpl, ItemTrait};
 
 use crate::getter_component::getter_field::GetterField;
+use crate::getter_component::{derive_getter_method, ContextArg};
 use crate::parse::ComponentSpec;
 
 pub fn derive_with_provider_impl(
@@ -16,19 +17,9 @@ pub fn derive_with_provider_impl(
     let context_type = &spec.context_type;
     let provider_name = &spec.provider_name;
 
-    let field_name = &field.field_name;
     let provider_type = &field.provider_type;
 
-    let provider_ident = quote! { __Provider__ };
-
-    let phantom_arg = match &field.phantom {
-        Some(phantom) => {
-            quote! {
-                , _phantom: #phantom
-            }
-        }
-        None => TokenStream::new(),
-    };
+    let provider_ident = Ident::new("__Provider__", Span::call_site());
 
     let provider_constraint = if field.field_mut.is_none() {
         quote! {
@@ -40,19 +31,12 @@ pub fn derive_with_provider_impl(
         }
     };
 
-    let method = if field.field_mut.is_none() {
-        quote! {
-            fn #field_name( context: & #context_type #phantom_arg ) -> & #provider_type {
-                #provider_ident ::get_field(context, ::core::marker::PhantomData )
-            }
-        }
-    } else {
-        quote! {
-            fn #field_name( context: &mut #context_type #phantom_arg ) -> &mut #provider_type {
-                #provider_ident ::get_field_mut(context, ::core::marker::PhantomData )
-            }
-        }
-    };
+    let method = derive_getter_method(
+        &ContextArg::Ident(context_type.clone()),
+        field,
+        None,
+        Some(provider_ident.clone()),
+    );
 
     let mut provider_generics = provider_trait.generics.clone();
 
@@ -65,7 +49,7 @@ pub fn derive_with_provider_impl(
 
     let impl_generics = {
         let mut generics: Generics = parse2(impl_generics.to_token_stream())?;
-        generics.params.push(parse2(provider_ident.clone())?);
+        generics.params.push(parse2(quote! { #provider_ident })?);
         generics
     };
 

--- a/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
@@ -1,3 +1,4 @@
+use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{parse2, Generics, ItemImpl, ItemTrait};
 
@@ -20,6 +21,15 @@ pub fn derive_with_provider_impl(
 
     let provider_ident = quote! { __Provider__ };
 
+    let phantom_arg = match &field.phantom {
+        Some(phantom) => {
+            quote! {
+                , _phantom: #phantom
+            }
+        }
+        None => TokenStream::new(),
+    };
+
     let provider_constraint = if field.field_mut.is_none() {
         quote! {
             FieldGetter< #context_type, #component_name < #component_params > , Value = #provider_type >
@@ -32,13 +42,13 @@ pub fn derive_with_provider_impl(
 
     let method = if field.field_mut.is_none() {
         quote! {
-            fn #field_name( context: & #context_type ) -> & #provider_type {
+            fn #field_name( context: & #context_type #phantom_arg ) -> & #provider_type {
                 #provider_ident ::get_field(context, ::core::marker::PhantomData )
             }
         }
     } else {
         quote! {
-            fn #field_name( context: &mut #context_type ) -> &mut #provider_type {
+            fn #field_name( context: &mut #context_type #phantom_arg ) -> &mut #provider_type {
                 #provider_ident ::get_field_mut(context, ::core::marker::PhantomData )
             }
         }

--- a/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
+++ b/crates/cgp-component-macro-lib/src/getter_component/with_provider.rs
@@ -17,7 +17,7 @@ pub fn derive_with_provider_impl(
     let context_type = &spec.context_type;
     let provider_name = &spec.provider_name;
 
-    let provider_type = &field.provider_type;
+    let provider_type = &field.field_type;
 
     let provider_ident = Ident::new("__Provider__", Span::call_site());
 

--- a/crates/cgp-component-macro-lib/src/parse/simple_type.rs
+++ b/crates/cgp-component-macro-lib/src/parse/simple_type.rs
@@ -1,3 +1,4 @@
+use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::token::Lt;
 use syn::Ident;
@@ -20,5 +21,12 @@ impl Parse for SimpleType {
         };
 
         Ok(Self { name, generics })
+    }
+}
+
+impl ToTokens for SimpleType {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.name.to_tokens(tokens);
+        self.generics.to_tokens(tokens);
     }
 }

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -363,15 +363,15 @@ fn test_derive_getter_with_component_generics() {
 fn test_derive_getter_with_phantom() {
     let derived = cgp_getter(
         quote! {
-            name: NameGetterComponent<App>,
+            name: NameGetterComponent,
             provider: NameGetter,
         },
         quote! {
-            pub trait HasName<App>
+            pub trait HasName<App, B>
             where
                 App: HasNameType,
             {
-                fn name(&self, _phantom: PhantomData<App>) -> &App::Name;
+                fn name(&self, _phantom: PhantomData<(App, B)>) -> &App::Name;
             }
         },
     )

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -134,7 +134,84 @@ fn test_derive_getter_str() {
     )
     .unwrap();
 
-    let expected = quote! {};
+    let expected = quote! {
+        pub struct NameGetterComponent;
+        pub trait HasName {
+            fn name(&self) -> &str;
+        }
+        pub trait NameGetter<Context>: IsProviderFor<NameGetterComponent, Context, ()> {
+            fn name(context: &Context) -> &str;
+        }
+        impl<Context> HasName for Context
+        where
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context>,
+        {
+            fn name(&self) -> &str {
+                Context::Provider::name(self)
+            }
+        }
+        impl<Component, Context> NameGetter<Context> for Component
+        where
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, ()>,
+            Component::Delegate: NameGetter<Context>,
+        {
+            fn name(context: &Context) -> &str {
+                Component::Delegate::name(context)
+            }
+        }
+        impl<Context> NameGetter<Context> for UseFields
+        where
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = String,
+            >,
+        {
+            fn name(context: &Context) -> &str {
+                context
+                    .get_field(
+                        ::core::marker::PhantomData::<
+                            Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                        >,
+                    )
+                    .as_str()
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseFields where
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = String,
+            >
+        {
+        }
+        impl<Context, __Tag__> NameGetter<Context> for UseField<__Tag__>
+        where
+            Context: HasField<__Tag__, Value = String>,
+        {
+            fn name(context: &Context) -> &str {
+                context.get_field(::core::marker::PhantomData).as_str()
+            }
+        }
+        impl<Context, __Tag__> IsProviderFor<NameGetterComponent, Context, ()> for UseField<__Tag__> where
+            Context: HasField<__Tag__, Value = String>
+        {
+        }
+        impl<Context, __Provider__> NameGetter<Context> for WithProvider<__Provider__>
+        where
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = String>,
+        {
+            fn name(context: &Context) -> &str {
+                __Provider__::get_field(context, ::core::marker::PhantomData).as_str()
+            }
+        }
+        impl<Context, __Provider__> IsProviderFor<NameGetterComponent, Context, ()>
+            for WithProvider<__Provider__>
+        where
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = String>,
+        {
+        }
+    };
 
     assert_equal_token_stream(&derived, &expected);
 }
@@ -153,7 +230,86 @@ fn test_derive_getter_mut_str() {
     )
     .unwrap();
 
-    let expected = quote! {};
+    let expected = quote! {
+        pub struct NameGetterComponent;
+        pub trait HasName {
+            fn name(&mut self) -> &mut str;
+        }
+        pub trait NameGetter<Context>: IsProviderFor<NameGetterComponent, Context, ()> {
+            fn name(context: &mut Context) -> &mut str;
+        }
+        impl<Context> HasName for Context
+        where
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context>,
+        {
+            fn name(&mut self) -> &mut str {
+                Context::Provider::name(self)
+            }
+        }
+        impl<Component, Context> NameGetter<Context> for Component
+        where
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, ()>,
+            Component::Delegate: NameGetter<Context>,
+        {
+            fn name(context: &mut Context) -> &mut str {
+                Component::Delegate::name(context)
+            }
+        }
+        impl<Context> NameGetter<Context> for UseFields
+        where
+            Context: HasFieldMut<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = String,
+            >,
+        {
+            fn name(context: &mut Context) -> &mut str {
+                context
+                    .get_field_mut(
+                        ::core::marker::PhantomData::<
+                            Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                        >,
+                    )
+                    .as_mut_str()
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseFields where
+            Context: HasFieldMut<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = String,
+            >
+        {
+        }
+        impl<Context, __Tag__> NameGetter<Context> for UseField<__Tag__>
+        where
+            Context: HasFieldMut<__Tag__, Value = String>,
+        {
+            fn name(context: &mut Context) -> &mut str {
+                context
+                    .get_field_mut(::core::marker::PhantomData)
+                    .as_mut_str()
+            }
+        }
+        impl<Context, __Tag__> IsProviderFor<NameGetterComponent, Context, ()> for UseField<__Tag__> where
+            Context: HasFieldMut<__Tag__, Value = String>
+        {
+        }
+        impl<Context, __Provider__> NameGetter<Context> for WithProvider<__Provider__>
+        where
+            __Provider__: MutFieldGetter<Context, NameGetterComponent, Value = String>,
+        {
+            fn name(context: &mut Context) -> &mut str {
+                __Provider__::get_field_mut(context, ::core::marker::PhantomData).as_mut_str()
+            }
+        }
+        impl<Context, __Provider__> IsProviderFor<NameGetterComponent, Context, ()>
+            for WithProvider<__Provider__>
+        where
+            __Provider__: MutFieldGetter<Context, NameGetterComponent, Value = String>,
+        {
+        }
+    };
 
     assert_equal_token_stream(&derived, &expected);
 }
@@ -172,7 +328,97 @@ fn test_derive_getter_clone() {
     )
     .unwrap();
 
-    let expected = quote! {};
+    let expected = quote! {
+        pub struct NameGetterComponent;
+        pub trait HasName: HasNameType<Name: Clone> {
+            fn name(&self) -> Self::Name;
+        }
+        pub trait NameGetter<Context>: IsProviderFor<NameGetterComponent, Context, ()>
+        where
+            Context: HasNameType<Name: Clone>,
+        {
+            fn name(context: &Context) -> Context::Name;
+        }
+        impl<Context> HasName for Context
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context>,
+        {
+            fn name(&self) -> Self::Name {
+                Context::Provider::name(self)
+            }
+        }
+        impl<Component, Context> NameGetter<Context> for Component
+        where
+            Context: HasNameType<Name: Clone>,
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, ()>,
+            Component::Delegate: NameGetter<Context>,
+        {
+            fn name(context: &Context) -> Context::Name {
+                Component::Delegate::name(context)
+            }
+        }
+        impl<Context> NameGetter<Context> for UseFields
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Context::Name,
+            >,
+        {
+            fn name(context: &Context) -> Context::Name {
+                context
+                    .get_field(
+                        ::core::marker::PhantomData::<
+                            Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                        >,
+                    )
+                    .clone()
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseFields
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Context::Name,
+            >,
+        {
+        }
+        impl<Context, __Tag__> NameGetter<Context> for UseField<__Tag__>
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasField<__Tag__, Value = Context::Name>,
+        {
+            fn name(context: &Context) -> Context::Name {
+                context.get_field(::core::marker::PhantomData).clone()
+            }
+        }
+        impl<Context, __Tag__> IsProviderFor<NameGetterComponent, Context, ()> for UseField<__Tag__>
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasField<__Tag__, Value = Context::Name>,
+        {
+        }
+        impl<Context, __Provider__> NameGetter<Context> for WithProvider<__Provider__>
+        where
+            Context: HasNameType<Name: Clone>,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = Context::Name>,
+        {
+            fn name(context: &Context) -> Context::Name {
+                __Provider__::get_field(context, ::core::marker::PhantomData).clone()
+            }
+        }
+        impl<Context, __Provider__> IsProviderFor<NameGetterComponent, Context, ()>
+            for WithProvider<__Provider__>
+        where
+            Context: HasNameType<Name: Clone>,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = Context::Name>,
+        {
+        }
+    };
 
     assert_equal_token_stream(&derived, &expected);
 }
@@ -191,7 +437,97 @@ fn test_derive_getter_option_ref() {
     )
     .unwrap();
 
-    let expected = quote! {};
+    let expected = quote! {
+        pub struct NameGetterComponent;
+        pub trait HasName: HasNameType {
+            fn name(&self) -> Option<&Self::Name>;
+        }
+        pub trait NameGetter<Context>: IsProviderFor<NameGetterComponent, Context, ()>
+        where
+            Context: HasNameType,
+        {
+            fn name(context: &Context) -> Option<&Context::Name>;
+        }
+        impl<Context> HasName for Context
+        where
+            Context: HasNameType,
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context>,
+        {
+            fn name(&self) -> Option<&Self::Name> {
+                Context::Provider::name(self)
+            }
+        }
+        impl<Component, Context> NameGetter<Context> for Component
+        where
+            Context: HasNameType,
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, ()>,
+            Component::Delegate: NameGetter<Context>,
+        {
+            fn name(context: &Context) -> Option<&Context::Name> {
+                Component::Delegate::name(context)
+            }
+        }
+        impl<Context> NameGetter<Context> for UseFields
+        where
+            Context: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Option<Context::Name>,
+            >,
+        {
+            fn name(context: &Context) -> Option<&Context::Name> {
+                context
+                    .get_field(
+                        ::core::marker::PhantomData::<
+                            Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                        >,
+                    )
+                    .as_ref()
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseFields
+        where
+            Context: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Option<Context::Name>,
+            >,
+        {
+        }
+        impl<Context, __Tag__> NameGetter<Context> for UseField<__Tag__>
+        where
+            Context: HasNameType,
+            Context: HasField<__Tag__, Value = Option<Context::Name>>,
+        {
+            fn name(context: &Context) -> Option<&Context::Name> {
+                context.get_field(::core::marker::PhantomData).as_ref()
+            }
+        }
+        impl<Context, __Tag__> IsProviderFor<NameGetterComponent, Context, ()> for UseField<__Tag__>
+        where
+            Context: HasNameType,
+            Context: HasField<__Tag__, Value = Option<Context::Name>>,
+        {
+        }
+        impl<Context, __Provider__> NameGetter<Context> for WithProvider<__Provider__>
+        where
+            Context: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = Option<Context::Name>>,
+        {
+            fn name(context: &Context) -> Option<&Context::Name> {
+                __Provider__::get_field(context, ::core::marker::PhantomData).as_ref()
+            }
+        }
+        impl<Context, __Provider__> IsProviderFor<NameGetterComponent, Context, ()>
+            for WithProvider<__Provider__>
+        where
+            Context: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = Option<Context::Name>>,
+        {
+        }
+    };
 
     assert_equal_token_stream(&derived, &expected);
 }
@@ -210,7 +546,97 @@ fn test_derive_getter_option_mut() {
     )
     .unwrap();
 
-    let expected = quote! {};
+    let expected = quote! {
+        pub struct NameGetterComponent;
+        pub trait HasName: HasNameType {
+            fn name(&mut self) -> Option<&mut Self::Name>;
+        }
+        pub trait NameGetter<Context>: IsProviderFor<NameGetterComponent, Context, ()>
+        where
+            Context: HasNameType,
+        {
+            fn name(context: &mut Context) -> Option<&mut Context::Name>;
+        }
+        impl<Context> HasName for Context
+        where
+            Context: HasNameType,
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context>,
+        {
+            fn name(&mut self) -> Option<&mut Self::Name> {
+                Context::Provider::name(self)
+            }
+        }
+        impl<Component, Context> NameGetter<Context> for Component
+        where
+            Context: HasNameType,
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, ()>,
+            Component::Delegate: NameGetter<Context>,
+        {
+            fn name(context: &mut Context) -> Option<&mut Context::Name> {
+                Component::Delegate::name(context)
+            }
+        }
+        impl<Context> NameGetter<Context> for UseFields
+        where
+            Context: HasNameType,
+            Context: HasFieldMut<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Option<Context::Name>,
+            >,
+        {
+            fn name(context: &mut Context) -> Option<&mut Context::Name> {
+                context
+                    .get_field_mut(
+                        ::core::marker::PhantomData::<
+                            Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                        >,
+                    )
+                    .as_mut()
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseFields
+        where
+            Context: HasNameType,
+            Context: HasFieldMut<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = Option<Context::Name>,
+            >,
+        {
+        }
+        impl<Context, __Tag__> NameGetter<Context> for UseField<__Tag__>
+        where
+            Context: HasNameType,
+            Context: HasFieldMut<__Tag__, Value = Option<Context::Name>>,
+        {
+            fn name(context: &mut Context) -> Option<&mut Context::Name> {
+                context.get_field_mut(::core::marker::PhantomData).as_mut()
+            }
+        }
+        impl<Context, __Tag__> IsProviderFor<NameGetterComponent, Context, ()> for UseField<__Tag__>
+        where
+            Context: HasNameType,
+            Context: HasFieldMut<__Tag__, Value = Option<Context::Name>>,
+        {
+        }
+        impl<Context, __Provider__> NameGetter<Context> for WithProvider<__Provider__>
+        where
+            Context: HasNameType,
+            __Provider__: MutFieldGetter<Context, NameGetterComponent, Value = Option<Context::Name>>,
+        {
+            fn name(context: &mut Context) -> Option<&mut Context::Name> {
+                __Provider__::get_field_mut(context, ::core::marker::PhantomData).as_mut()
+            }
+        }
+        impl<Context, __Provider__> IsProviderFor<NameGetterComponent, Context, ()>
+            for WithProvider<__Provider__>
+        where
+            Context: HasNameType,
+            __Provider__: MutFieldGetter<Context, NameGetterComponent, Value = Option<Context::Name>>,
+        {
+        }
+    };
 
     assert_equal_token_stream(&derived, &expected);
 }

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -121,6 +121,63 @@ fn test_derive_getter_basic() {
 }
 
 #[test]
+fn test_derive_getter_str() {
+    let derived = cgp_getter(
+        quote! {
+            provider: NameGetter,
+        },
+        quote! {
+            pub trait HasName {
+                fn name(&self) -> &str;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {};
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
+fn test_derive_getter_clone() {
+    let derived = cgp_getter(
+        quote! {
+            provider: NameGetter,
+        },
+        quote! {
+            pub trait HasName: HasNameType<Name: Clone> {
+                fn name(&self) -> Self::Name;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {};
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
+fn test_derive_getter_option_ref() {
+    let derived = cgp_getter(
+        quote! {
+            provider: NameGetter,
+        },
+        quote! {
+            pub trait HasName: HasNameType {
+                fn name(&self) -> Option<&Self::Name>;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {};
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
 fn test_derive_getter_with_generics() {
     let derived = cgp_getter(
         quote! {

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -377,7 +377,100 @@ fn test_derive_getter_with_phantom() {
     )
     .unwrap();
 
-    let expected = quote! {};
+    let expected = quote! {
+        pub struct NameGetterComponent;
+        pub trait HasName<App, B>
+        where
+            App: HasNameType,
+        {
+            fn name(&self, _phantom: PhantomData<(App, B)>) -> &App::Name;
+        }
+        pub trait NameGetter<Context, App, B>:
+            IsProviderFor<NameGetterComponent, Context, (App, B)>
+        where
+            App: HasNameType,
+        {
+            fn name(context: &Context, _phantom: PhantomData<(App, B)>) -> &App::Name;
+        }
+        impl<Context, App, B> HasName<App, B> for Context
+        where
+            App: HasNameType,
+            Context: HasProvider,
+            Context::Provider: NameGetter<Context, App, B>,
+        {
+            fn name(&self, _phantom: PhantomData<(App, B)>) -> &App::Name {
+                Context::Provider::name(self, _phantom)
+            }
+        }
+        impl<Component, Context, App, B> NameGetter<Context, App, B> for Component
+        where
+            App: HasNameType,
+            Component: DelegateComponent<NameGetterComponent>
+                + IsProviderFor<NameGetterComponent, Context, (App, B)>,
+            Component::Delegate: NameGetter<Context, App, B>,
+        {
+            fn name(context: &Context, _phantom: PhantomData<(App, B)>) -> &App::Name {
+                Component::Delegate::name(context, _phantom)
+            }
+        }
+        impl<Context, App, B> NameGetter<Context, App, B> for UseFields
+        where
+            App: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = App::Name,
+            >,
+        {
+            fn name(context: &Context, _phantom: PhantomData<(App, B)>) -> &App::Name {
+                context.get_field(
+                    ::core::marker::PhantomData::<
+                        Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                    >,
+                )
+            }
+        }
+        impl<Context, App, B> IsProviderFor<NameGetterComponent, Context, (App, B)> for UseFields
+        where
+            App: HasNameType,
+            Context: HasField<
+                Cons<Char<'n'>, Cons<Char<'a'>, Cons<Char<'m'>, Cons<Char<'e'>, Nil>>>>,
+                Value = App::Name,
+            >,
+        {
+        }
+        impl<Context, App, B, __Tag__> NameGetter<Context, App, B> for UseField<__Tag__>
+        where
+            App: HasNameType,
+            Context: HasField<__Tag__, Value = App::Name>,
+        {
+            fn name(context: &Context, _phantom: PhantomData<(App, B)>) -> &App::Name {
+                context.get_field(::core::marker::PhantomData)
+            }
+        }
+        impl<Context, App, B, __Tag__> IsProviderFor<NameGetterComponent, Context, (App, B)>
+            for UseField<__Tag__>
+        where
+            App: HasNameType,
+            Context: HasField<__Tag__, Value = App::Name>,
+        {
+        }
+        impl<Context, App, B, __Provider__> NameGetter<Context, App, B> for WithProvider<__Provider__>
+        where
+            App: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = App::Name>,
+        {
+            fn name(context: &Context, _phantom: PhantomData<(App, B)>) -> &App::Name {
+                __Provider__::get_field(context, ::core::marker::PhantomData)
+            }
+        }
+        impl<Context, App, B, __Provider__> IsProviderFor<NameGetterComponent, Context, (App, B)>
+            for WithProvider<__Provider__>
+        where
+            App: HasNameType,
+            __Provider__: FieldGetter<Context, NameGetterComponent, Value = App::Name>,
+        {
+        }
+    };
 
     assert_equal_token_stream(&derived, &expected);
 }

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -140,6 +140,25 @@ fn test_derive_getter_str() {
 }
 
 #[test]
+fn test_derive_getter_mut_str() {
+    let derived = cgp_getter(
+        quote! {
+            provider: NameGetter,
+        },
+        quote! {
+            pub trait HasName {
+                fn name(&mut self) -> &mut str;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {};
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
 fn test_derive_getter_clone() {
     let derived = cgp_getter(
         quote! {
@@ -167,6 +186,25 @@ fn test_derive_getter_option_ref() {
         quote! {
             pub trait HasName: HasNameType {
                 fn name(&self) -> Option<&Self::Name>;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {};
+
+    assert_equal_token_stream(&derived, &expected);
+}
+
+#[test]
+fn test_derive_getter_option_mut() {
+    let derived = cgp_getter(
+        quote! {
+            provider: NameGetter,
+        },
+        quote! {
+            pub trait HasName: HasNameType {
+                fn name(&mut self) -> Option<&mut Self::Name>;
             }
         },
     )

--- a/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-component-macro-lib/src/tests/derive_getter.rs
@@ -358,3 +358,26 @@ fn test_derive_getter_with_component_generics() {
 
     assert_equal_token_stream(&derived, &expected);
 }
+
+#[test]
+fn test_derive_getter_with_phantom() {
+    let derived = cgp_getter(
+        quote! {
+            name: NameGetterComponent<App>,
+            provider: NameGetter,
+        },
+        quote! {
+            pub trait HasName<App>
+            where
+                App: HasNameType,
+            {
+                fn name(&self, _phantom: PhantomData<App>) -> &App::Name;
+            }
+        },
+    )
+    .unwrap();
+
+    let expected = quote! {};
+
+    assert_equal_token_stream(&derived, &expected);
+}

--- a/crates/cgp-field/src/impls/mod.rs
+++ b/crates/cgp-field/src/impls/mod.rs
@@ -1,3 +1,5 @@
 mod use_field;
+mod use_ref;
 
-pub use use_field::{UseField, WithField};
+pub use use_field::*;
+pub use use_ref::*;

--- a/crates/cgp-field/src/impls/use_ref.rs
+++ b/crates/cgp-field/src/impls/use_ref.rs
@@ -1,0 +1,29 @@
+use core::marker::PhantomData;
+
+use cgp_component::WithProvider;
+
+use crate::{FieldGetter, HasField, HasFieldMut, MutFieldGetter};
+
+pub struct UseFieldRef<Tag, Value>(pub PhantomData<(Tag, Value)>);
+
+pub type WithFieldRef<Tag, Value> = WithProvider<UseFieldRef<Tag, Value>>;
+
+impl<Context, OutTag, Tag, Value> FieldGetter<Context, OutTag> for UseFieldRef<Tag, Value>
+where
+    Context: HasField<Tag, Value: AsRef<Value> + 'static>,
+{
+    type Value = Value;
+
+    fn get_field(context: &Context, _tag: PhantomData<OutTag>) -> &Value {
+        context.get_field(PhantomData).as_ref()
+    }
+}
+
+impl<Context, OutTag, Tag, Value> MutFieldGetter<Context, OutTag> for UseFieldRef<Tag, Value>
+where
+    Context: HasFieldMut<Tag, Value: AsRef<Value> + AsMut<Value> + 'static>,
+{
+    fn get_field_mut(context: &mut Context, _tag: PhantomData<OutTag>) -> &mut Value {
+        context.get_field_mut(PhantomData).as_mut()
+    }
+}

--- a/crates/cgp-field/src/lib.rs
+++ b/crates/cgp-field/src/lib.rs
@@ -4,6 +4,6 @@ mod impls;
 mod traits;
 mod types;
 
-pub use impls::{UseField, WithField};
+pub use impls::{UseField, UseFieldRef, WithField, WithFieldRef};
 pub use traits::{FieldGetter, HasField, HasFieldMut, MutFieldGetter};
 pub use types::{Char, Cons, Either, Field, Index, Nil, Void};


### PR DESCRIPTION
## Summary

This PR brings several quality of life improvements on the proc macros `#[cgp_getter]` and `#[cgp_auto_getter]`, allowing them to support more general getter interfaces to be defined.

## Specialized `&str` Field

Getter methods can now return `&str` instead of `&String` to derive `UseField` implementations that require the context to contain a `String` field.

For example, the following `HasName` trait will be implemented for any context struct that contains `name: String`:

```rust
#[cgp_auto_getter]
pub trait HasName {
    fn name(&self) -> &str;
}
```

## Specialized `Option<&T>` Field

Getter methods can now return `Option<&T>` instead of `&Option<T>` to derive `UseField` implementations that require the context to contain an `Option<T>` field.

For example, the following `HasName` trait will be implemented for any context struct that contains `name: Option<Self::Name>`:

```rust
#[cgp_auto_getter]
pub trait HasName: HasNameType {
    fn name(&self) -> Option<&Self::Name>;
}
```

## Specialized `Clone`eable Field

Getter methods can now return owned values instead of references. The derived implementation will require the value type to implement `Clone`.

For example, the following `HasName` trait will be implemented for any context struct that contains `name: Self::Name` with `Self::Name: Clone`:

```rust

#[cgp_auto_getter]
pub trait HasName: HasNameType<Name: Clone> {
    fn name(&self) -> Self::Name;
}
```

## `PhantomData` Tag Argument

A second `PhantomData` argument can now be provided in getter methods to help with type inferences, in case when the getter trait contains generic parameters.

Example:

```rust
pub trait HasName<App>
where
    App: HasNameType,
{
    fn name(&self, _tag: PhantomData<App>) -> &App::Name;
}
```

## `WithFieldRef`

A `UseFieldRef` provider has been implemented as a complement of `UseField`, which allows accessing a field value using `AsRef`. This allows field accessors to be implemented on structs that do not contain the exact same type, such as values that are wrapped in `Box` or `Arc`.

For example, the following `Person` context implements `HasName` that returns `String`, even though the context contains a `name` field of type `Box<String>`:

```rust
#[cgp_getter {
    provider: NameGetter,
}]
pub trait HasName {
    fn name(&self) -> &String;
}

#[cgp_context(PersonProvider)]
#[derive(HasField)]
pub struct Person {
    pub name: Box<String>,
}

delegate_components! {
    PersonProvider {
        NameGetterComponent: WithFieldRef<symbol!("name"), String>,
    }
}

check_components! {
    CanUsePerson for Person {
        NameGetterComponent,
    }
}
```