### PR TITLE
Getter Macro Improvements

### DIFF
--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -9,7 +9,7 @@ pub use cgp_error::{
 };
 pub use cgp_field::{
     Char, Cons, Either, Field, FieldGetter, FromFields, HasField, HasFieldMut, HasFields,
-    HasFieldsRef, Index, MutFieldGetter, Nil, ToFields, ToFieldsRef, UseField, Void,
+    HasFieldsRef, Index, MRef, MutFieldGetter, Nil, ToFields, ToFieldsRef, UseField, Void,
 };
 pub use cgp_macro::{
     cgp_auto_getter, cgp_component, cgp_context, cgp_getter, cgp_new_provider, cgp_preset,

--- a/crates/cgp-field/src/types/mod.rs
+++ b/crates/cgp-field/src/types/mod.rs
@@ -1,11 +1,13 @@
 mod char;
 mod field;
 mod index;
+mod mref;
 mod product;
 mod sum;
 
 pub use char::*;
 pub use field::*;
 pub use index::*;
+pub use mref::*;
 pub use product::*;
 pub use sum::*;

--- a/crates/cgp-field/src/types/mref.rs
+++ b/crates/cgp-field/src/types/mref.rs
@@ -5,7 +5,7 @@ pub enum MRef<'a, T> {
     Owned(T),
 }
 
-impl<'a, T> Deref for MRef<'a, T> {
+impl<T> Deref for MRef<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -16,13 +16,13 @@ impl<'a, T> Deref for MRef<'a, T> {
     }
 }
 
-impl<'a, T> AsRef<T> for MRef<'a, T> {
+impl<T> AsRef<T> for MRef<'_, T> {
     fn as_ref(&self) -> &T {
         self.deref()
     }
 }
 
-impl<'a, T> From<T> for MRef<'a, T> {
+impl<T> From<T> for MRef<'_, T> {
     fn from(value: T) -> Self {
         Self::Owned(value)
     }
@@ -34,7 +34,7 @@ impl<'a, T> From<&'a T> for MRef<'a, T> {
     }
 }
 
-impl<'a, T> MRef<'a, T>
+impl<T> MRef<'_, T>
 where
     T: Clone,
 {

--- a/crates/cgp-field/src/types/mref.rs
+++ b/crates/cgp-field/src/types/mref.rs
@@ -21,3 +21,27 @@ impl<'a, T> AsRef<T> for MRef<'a, T> {
         self.deref()
     }
 }
+
+impl<'a, T> From<T> for MRef<'a, T> {
+    fn from(value: T) -> Self {
+        Self::Owned(value)
+    }
+}
+
+impl<'a, T> From<&'a T> for MRef<'a, T> {
+    fn from(value: &'a T) -> Self {
+        Self::Ref(value)
+    }
+}
+
+impl<'a, T> MRef<'a, T>
+where
+    T: Clone,
+{
+    pub fn get_or_clone(self) -> T {
+        match self {
+            Self::Ref(value) => value.clone(),
+            Self::Owned(value) => value,
+        }
+    }
+}

--- a/crates/cgp-field/src/types/mref.rs
+++ b/crates/cgp-field/src/types/mref.rs
@@ -1,0 +1,23 @@
+use core::ops::Deref;
+
+pub enum MRef<'a, T> {
+    Ref(&'a T),
+    Owned(T),
+}
+
+impl<'a, T> Deref for MRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            Self::Ref(value) => value,
+            Self::Owned(value) => value,
+        }
+    }
+}
+
+impl<'a, T> AsRef<T> for MRef<'a, T> {
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}

--- a/crates/cgp-macro-lib/src/derive_getter/constraint.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/constraint.rs
@@ -13,7 +13,7 @@ pub fn derive_getter_constraint(
     let constraint = if spec.field_mut.is_none() {
         if let FieldMode::Slice = spec.field_mode {
             quote! {
-                HasField< #field_symbol, Value: AsRef< [ #provider_type ] >
+                HasField< #field_symbol, Value: AsRef< [ #provider_type ] > + 'static >
             }
         } else {
             quote! {

--- a/crates/cgp-macro-lib/src/derive_getter/constraint.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/constraint.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse2, TypeParamBound};
 
-use crate::derive_getter::GetterField;
+use crate::derive_getter::{FieldMode, GetterField};
 
 pub fn derive_getter_constraint(
     spec: &GetterField,
@@ -11,8 +11,14 @@ pub fn derive_getter_constraint(
     let provider_type = &spec.field_type;
 
     let constraint = if spec.field_mut.is_none() {
-        quote! {
-            HasField< #field_symbol, Value = #provider_type >
+        if let FieldMode::Slice = spec.field_mode {
+            quote! {
+                HasField< #field_symbol, Value: AsRef< [ #provider_type ] >
+            }
+        } else {
+            quote! {
+                HasField< #field_symbol, Value = #provider_type >
+            }
         }
     } else {
         quote! {

--- a/crates/cgp-macro-lib/src/derive_getter/getter_field.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/getter_field.rs
@@ -16,4 +16,5 @@ pub enum FieldMode {
     MRef,
     Str,
     Clone,
+    Slice,
 }

--- a/crates/cgp-macro-lib/src/derive_getter/getter_field.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/getter_field.rs
@@ -13,6 +13,7 @@ pub struct GetterField {
 pub enum FieldMode {
     Reference,
     OptionRef,
+    MRef,
     Str,
     Clone,
 }

--- a/crates/cgp-macro-lib/src/derive_getter/method.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/method.rs
@@ -100,9 +100,16 @@ pub fn derive_getter_method(
                 }
             }
         }
-        FieldMode::Clone => quote! {
-            #call_expr .clone()
-        },
+        FieldMode::Clone => {
+            quote! {
+                #call_expr .clone()
+            }
+        }
+        FieldMode::Slice => {
+            quote! {
+                #call_expr .as_ref()
+            }
+        }
     };
 
     let return_type = &spec.return_type;

--- a/crates/cgp-macro-lib/src/derive_getter/method.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/method.rs
@@ -84,6 +84,11 @@ pub fn derive_getter_method(
                 }
             }
         }
+        FieldMode::MRef => {
+            quote! {
+                MRef::Ref( #call_expr )
+            }
+        }
         FieldMode::Str => {
             if spec.field_mut.is_none() {
                 quote! {

--- a/crates/cgp-macro-lib/src/derive_getter/parse.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/parse.rs
@@ -207,11 +207,11 @@ fn parse_field_type(return_type: &Type, field_mut: &Option<Mut>) -> syn::Result<
 
                 Ok((field_type, FieldMode::Str))
             } else if let (Type::Slice(slice), None) = (type_ref.elem.as_ref(), field_mut) {
-                let field_type: Type = slice.elem.as_ref().clone();
+                let field_type = slice.elem.as_ref().clone();
 
                 Ok((field_type, FieldMode::Slice))
             } else {
-                let field_type: Type = type_ref.elem.as_ref().clone();
+                let field_type = type_ref.elem.as_ref().clone();
 
                 Ok((field_type, FieldMode::Reference))
             }

--- a/crates/cgp-macro-lib/src/derive_getter/parse.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/parse.rs
@@ -218,6 +218,8 @@ fn parse_field_type(return_type: &Type, field_mut: &Option<Mut>) -> syn::Result<
                     parse2(quote! { Option< #field_type > })?,
                     FieldMode::OptionRef,
                 ))
+            } else if let (Some(field_type), None) = (try_parse_mref(type_path), field_mut) {
+                Ok((field_type.clone(), FieldMode::MRef))
             } else {
                 Ok((return_type.clone(), FieldMode::Clone))
             }
@@ -263,8 +265,27 @@ fn try_parse_option_ref(type_path: &TypePath) -> Option<&Type> {
 
     if segment.ident == "Option" {
         if let PathArguments::AngleBracketed(args) = &segment.arguments {
-            if let Some(GenericArgument::Type(Type::Reference(type_ref))) = args.args.first() {
+            let [arg] = Vec::from_iter(args.args.iter()).try_into().ok()?;
+
+            if let GenericArgument::Type(Type::Reference(type_ref)) = arg {
                 return Some(type_ref.elem.as_ref());
+            }
+        }
+    }
+
+    None
+}
+
+fn try_parse_mref(type_path: &TypePath) -> Option<&Type> {
+    let segment = parse_single_segment_type_path(type_path).ok()?;
+
+    if segment.ident == "MRef" {
+        if let PathArguments::AngleBracketed(args) = &segment.arguments {
+            let [arg1, arg2] = Vec::from_iter(args.args.iter()).try_into().ok()?;
+
+            match (arg1, arg2) {
+                (GenericArgument::Lifetime(_), GenericArgument::Type(ty)) => return Some(ty),
+                _ => {}
             }
         }
     }

--- a/crates/cgp-macro-lib/src/derive_getter/parse.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/parse.rs
@@ -206,6 +206,10 @@ fn parse_field_type(return_type: &Type, field_mut: &Option<Mut>) -> syn::Result<
                 let field_type: Type = parse_quote! { String };
 
                 Ok((field_type, FieldMode::Str))
+            } else if let (Type::Slice(slice), None) = (type_ref.elem.as_ref(), field_mut) {
+                let field_type: Type = slice.elem.as_ref().clone();
+
+                Ok((field_type, FieldMode::Slice))
             } else {
                 let field_type: Type = type_ref.elem.as_ref().clone();
 

--- a/crates/cgp-macro-lib/src/derive_getter/parse.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/parse.rs
@@ -287,10 +287,7 @@ fn try_parse_mref(type_path: &TypePath) -> Option<&Type> {
         if let PathArguments::AngleBracketed(args) = &segment.arguments {
             let [arg1, arg2] = Vec::from_iter(args.args.iter()).try_into().ok()?;
 
-            match (arg1, arg2) {
-                (GenericArgument::Lifetime(_), GenericArgument::Type(ty)) => return Some(ty),
-                _ => {}
-            }
+            if let (GenericArgument::Lifetime(_), GenericArgument::Type(ty)) = (arg1, arg2) { return Some(ty) }
         }
     }
 

--- a/crates/cgp-macro-lib/src/derive_getter/parse.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/parse.rs
@@ -287,7 +287,9 @@ fn try_parse_mref(type_path: &TypePath) -> Option<&Type> {
         if let PathArguments::AngleBracketed(args) = &segment.arguments {
             let [arg1, arg2] = Vec::from_iter(args.args.iter()).try_into().ok()?;
 
-            if let (GenericArgument::Lifetime(_), GenericArgument::Type(ty)) = (arg1, arg2) { return Some(ty) }
+            if let (GenericArgument::Lifetime(_), GenericArgument::Type(ty)) = (arg1, arg2) {
+                return Some(ty);
+            }
         }
     }
 

--- a/crates/cgp-macro-lib/src/derive_getter/with_provider.rs
+++ b/crates/cgp-macro-lib/src/derive_getter/with_provider.rs
@@ -3,7 +3,7 @@ use quote::{quote, ToTokens};
 use syn::{parse2, Generics, Ident, ItemImpl, ItemTrait};
 
 use crate::derive_getter::getter_field::GetterField;
-use crate::derive_getter::{derive_getter_method, ContextArg};
+use crate::derive_getter::{derive_getter_method, ContextArg, FieldMode};
 use crate::parse::ComponentSpec;
 
 pub fn derive_with_provider_impl(
@@ -24,8 +24,14 @@ pub fn derive_with_provider_impl(
     let component_type = quote! { #component_name < #component_params > };
 
     let provider_constraint = if field.field_mut.is_none() {
-        quote! {
-            FieldGetter< #context_type, #component_type , Value = #provider_type >
+        if let FieldMode::Slice = field.field_mode {
+            quote! {
+                FieldGetter< #context_type, #component_type, Value: AsRef< [ #provider_type ] > + 'static >
+            }
+        } else {
+            quote! {
+                FieldGetter< #context_type, #component_type , Value = #provider_type >
+            }
         }
     } else {
         quote! {

--- a/crates/cgp-tests/src/tests/getter/abstract_type.rs
+++ b/crates/cgp-tests/src/tests/getter/abstract_type.rs
@@ -1,0 +1,66 @@
+use cgp::prelude::*;
+
+#[test]
+pub fn test_abstract_type_getter() {
+    #[cgp_type]
+    pub trait HasNameType {
+        type Name;
+    }
+
+    #[cgp_getter {
+        provider: NameGetter,
+    }]
+    pub trait HasName: HasNameType {
+        fn name(&self) -> &Self::Name;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub name: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            NameTypeProviderComponent: UseType<String>,
+            NameGetterComponent: UseField<symbol!("name")>,
+        }
+    }
+
+    let context = App {
+        name: "Alice".to_owned(),
+    };
+
+    assert_eq!(context.name(), "Alice");
+}
+
+#[test]
+pub fn test_abstract_type_auto_getter() {
+    #[cgp_type]
+    pub trait HasNameType {
+        type Name;
+    }
+
+    #[cgp_auto_getter]
+    pub trait HasName: HasNameType {
+        fn name(&self) -> &Self::Name;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub name: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            NameTypeProviderComponent: UseType<String>,
+        }
+    }
+
+    let context = App {
+        name: "Alice".to_owned(),
+    };
+
+    assert_eq!(context.name(), "Alice");
+}

--- a/crates/cgp-tests/src/tests/getter/clone.rs
+++ b/crates/cgp-tests/src/tests/getter/clone.rs
@@ -1,0 +1,66 @@
+use cgp::prelude::*;
+
+#[test]
+pub fn test_clone_getter() {
+    #[cgp_type]
+    pub trait HasNameType {
+        type Name;
+    }
+
+    #[cgp_getter {
+        provider: NameGetter,
+    }]
+    pub trait HasName: HasNameType<Name: Clone> {
+        fn name(&self) -> Self::Name;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub name: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            NameTypeProviderComponent: UseType<String>,
+            NameGetterComponent: UseField<symbol!("name")>,
+        }
+    }
+
+    let context = App {
+        name: "Alice".to_owned(),
+    };
+
+    assert_eq!(context.name(), "Alice");
+}
+
+#[test]
+pub fn test_clone_auto_getter() {
+    #[cgp_type]
+    pub trait HasNameType {
+        type Name;
+    }
+
+    #[cgp_auto_getter]
+    pub trait HasName: HasNameType<Name: Clone> {
+        fn name(&self) -> Self::Name;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub name: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            NameTypeProviderComponent: UseType<String>,
+        }
+    }
+
+    let context = App {
+        name: "Alice".to_owned(),
+    };
+
+    assert_eq!(context.name(), "Alice");
+}

--- a/crates/cgp-tests/src/tests/getter/mod.rs
+++ b/crates/cgp-tests/src/tests/getter/mod.rs
@@ -1,0 +1,1 @@
+pub mod mref;

--- a/crates/cgp-tests/src/tests/getter/mod.rs
+++ b/crates/cgp-tests/src/tests/getter/mod.rs
@@ -1,1 +1,2 @@
 pub mod mref;
+pub mod slice;

--- a/crates/cgp-tests/src/tests/getter/mod.rs
+++ b/crates/cgp-tests/src/tests/getter/mod.rs
@@ -1,2 +1,6 @@
+pub mod abstract_type;
+pub mod clone;
 pub mod mref;
+pub mod option;
 pub mod slice;
+pub mod string;

--- a/crates/cgp-tests/src/tests/getter/mref.rs
+++ b/crates/cgp-tests/src/tests/getter/mref.rs
@@ -1,0 +1,44 @@
+use cgp::prelude::*;
+
+#[test]
+pub fn test_mref_getter() {
+    #[cgp_getter {
+        provider: FooGetter,
+    }]
+    pub trait HasFoo {
+        fn foo(&self) -> MRef<'_, String>;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub bar: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            FooGetterComponent: UseField<symbol!("bar")>,
+        }
+    }
+
+    let context = App { bar: "foo".into() };
+
+    assert_eq!(context.foo().as_ref(), "foo");
+}
+
+#[test]
+pub fn test_mref_auto_getter() {
+    #[cgp_auto_getter]
+    pub trait HasFoo {
+        fn foo(&self) -> MRef<'_, String>;
+    }
+
+    #[derive(HasField)]
+    pub struct App {
+        pub foo: String,
+    }
+
+    let context = App { foo: "foo".into() };
+
+    assert_eq!(context.foo().as_ref(), "foo");
+}

--- a/crates/cgp-tests/src/tests/getter/option.rs
+++ b/crates/cgp-tests/src/tests/getter/option.rs
@@ -1,0 +1,49 @@
+use cgp::prelude::*;
+
+#[test]
+pub fn test_option_getter() {
+    #[cgp_getter {
+        provider: FooGetter,
+    }]
+    pub trait HasFoo {
+        fn foo(&self) -> Option<&String>;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub bar: Option<String>,
+    }
+
+    delegate_components! {
+        AppComponents {
+            FooGetterComponent: UseField<symbol!("bar")>,
+        }
+    }
+
+    let context = App {
+        bar: Some("foo".to_owned()),
+    };
+
+    assert_eq!(context.foo(), Some(&"foo".to_owned()));
+}
+
+#[test]
+pub fn test_option_auto_getter() {
+    #[cgp_auto_getter]
+    pub trait HasFoo {
+        fn foo(&self) -> Option<&String>;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub foo: Option<String>,
+    }
+
+    let context = App {
+        foo: Some("foo".to_owned()),
+    };
+
+    assert_eq!(context.foo(), Some(&"foo".to_owned()));
+}

--- a/crates/cgp-tests/src/tests/getter/slice.rs
+++ b/crates/cgp-tests/src/tests/getter/slice.rs
@@ -1,0 +1,44 @@
+use cgp::prelude::*;
+
+#[test]
+pub fn test_slice_getter() {
+    #[cgp_getter {
+        provider: FooGetter,
+    }]
+    pub trait HasFoo {
+        fn foo(&self) -> &[u8];
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub bar: Vec<u8>,
+    }
+
+    delegate_components! {
+        AppComponents {
+            FooGetterComponent: UseField<symbol!("bar")>,
+        }
+    }
+
+    let context = App { bar: vec![1, 2, 3] };
+
+    assert_eq!(context.foo(), &[1, 2, 3]);
+}
+
+#[test]
+pub fn test_slice_auto_getter() {
+    #[cgp_auto_getter]
+    pub trait HasFoo {
+        fn foo(&self) -> &[u8];
+    }
+
+    #[derive(HasField)]
+    pub struct App {
+        pub foo: Vec<u8>,
+    }
+
+    let context = App { foo: vec![1, 2, 3] };
+
+    assert_eq!(context.foo(), &[1, 2, 3]);
+}

--- a/crates/cgp-tests/src/tests/getter/string.rs
+++ b/crates/cgp-tests/src/tests/getter/string.rs
@@ -1,0 +1,49 @@
+use cgp::prelude::*;
+
+#[test]
+pub fn test_string_getter() {
+    #[cgp_getter {
+        provider: FooGetter,
+    }]
+    pub trait HasFoo {
+        fn foo(&self) -> &str;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub bar: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            FooGetterComponent: UseField<symbol!("bar")>,
+        }
+    }
+
+    let context = App {
+        bar: "abc".to_owned(),
+    };
+
+    assert_eq!(context.foo(), "abc");
+}
+
+#[test]
+pub fn test_string_auto_getter() {
+    #[cgp_auto_getter]
+    pub trait HasFoo {
+        fn foo(&self) -> &str;
+    }
+
+    #[cgp_context(AppComponents)]
+    #[derive(HasField)]
+    pub struct App {
+        pub foo: String,
+    }
+
+    let context = App {
+        foo: "abc".to_owned(),
+    };
+
+    assert_eq!(context.foo(), "abc");
+}

--- a/crates/cgp-tests/src/tests/mod.rs
+++ b/crates/cgp-tests/src/tests/mod.rs
@@ -1,2 +1,3 @@
+pub mod getter;
 pub mod has_fields;
 pub mod symbol;


### PR DESCRIPTION
## Summary

This PR brings improvements to the `#[cgp_getter]` macro to support new kinds of getter fields to be derived.

## Slice Field

A getter method that returns slice reference, e.g. `&[u8]` can now be implemented with field types that implement `AsRef`.

Example:

```rust
#[cgp_auto_getter]
pub trait HasBytes {
    fn bytes(&self) -> &[u8];
}
```

## Maybe Reference

A new `MRef` type is introduced to allow either reference or owned value to be returned:

```rust
pub enum MRef<'a, T> {
    Ref(&'a T),
    Owned(T),
}
```

This type will be useful for custom field getter implementations, so that they can return owned values in case when it is a virtual field that is not directly present within a context.

The default `UseField` implementation will still require an actual field to be present, and use `MRef::Ref` to return the borrowed value.

Example:

```rust
#[cgp_getter {
    provider: NameGetter,
}]
pub trait HasName {
    fn name(&self) -> MRef<'_, String>;
}
```