### PR TITLE
Automatically derive `UseContext` implementation inside `#[cgp_component]`

### DIFF
--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use cgp_async::{async_trait, Async, MaybeSend, MaybeStatic, MaybeSync};
 pub use cgp_component::{
-    CanUseComponent, DelegateComponent, HasProvider, IsProviderFor, UseFields, WithContext,
-    WithProvider,
+    CanUseComponent, DelegateComponent, HasProvider, IsProviderFor, UseContext, UseFields,
+    WithContext, WithProvider,
 };
 pub use cgp_error::{
     CanRaiseAsyncError, CanRaiseError, CanWrapAsyncError, CanWrapError, HasAsyncErrorType,

--- a/crates/cgp-error/src/traits/can_raise_error.rs
+++ b/crates/cgp-error/src/traits/can_raise_error.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseDelegate};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, UseDelegate};
 use cgp_macro::{cgp_component, cgp_provider};
 
 use crate::traits::has_error_type::HasErrorType;

--- a/crates/cgp-error/src/traits/can_wrap_error.rs
+++ b/crates/cgp-error/src/traits/can_wrap_error.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseDelegate};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, UseDelegate};
 use cgp_macro::{cgp_component, cgp_provider};
 
 use crate::traits::HasErrorType;

--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, WithProvider};
+use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, WithProvider};
 use cgp_macro::cgp_type;
 use cgp_type::{ProvideType, UseType};
 

--- a/crates/cgp-macro-lib/src/derive_component/delegate_fn.rs
+++ b/crates/cgp-macro-lib/src/derive_component/delegate_fn.rs
@@ -2,14 +2,19 @@ use alloc::vec::Vec;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse2, ImplItemFn, Signature, TypePath, Visibility};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{parse2, ImplItemFn, Signature, Visibility};
 
 use crate::derive_component::signature_args::signature_to_args;
 
-pub fn derive_delegated_fn_impl(sig: &Signature, delegator: &TypePath) -> syn::Result<ImplItemFn> {
+pub fn derive_delegated_fn_impl(
+    sig: &Signature,
+    delegator: &TokenStream,
+) -> syn::Result<ImplItemFn> {
     let fn_name = &sig.ident;
 
-    let args = signature_to_args(sig);
+    let args: Punctuated<_, Comma> = signature_to_args(sig).collect();
 
     let await_expr: TokenStream = if sig.asyncness.is_some() {
         quote!( .await )

--- a/crates/cgp-macro-lib/src/derive_component/derive.rs
+++ b/crates/cgp-macro-lib/src/derive_component/derive.rs
@@ -1,11 +1,13 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
-use syn::{ItemImpl, ItemStruct, ItemTrait};
+use quote::{quote, ToTokens};
+use syn::{parse2, ItemImpl, ItemStruct, ItemTrait};
 
 use crate::derive_component::component_name::derive_component_name_struct;
 use crate::derive_component::consumer_impl::derive_consumer_impl;
 use crate::derive_component::provider_impl::derive_provider_impl;
 use crate::derive_component::provider_trait::derive_provider_trait;
+use crate::derive_component::use_context_impl::derive_use_context_impl;
+use crate::derive_provider::derive_is_provider_for;
 use crate::parse::ComponentSpec;
 
 pub fn derive_component_with_ast(
@@ -15,12 +17,14 @@ pub fn derive_component_with_ast(
     let provider_name = &spec.provider_name;
     let context_type = &spec.context_type;
 
-    let component_struct =
-        derive_component_name_struct(&spec.component_name, &spec.component_params)?;
+    let component_name = &spec.component_name;
+    let component_params = &spec.component_params;
+
+    let component_struct = derive_component_name_struct(component_name, component_params)?;
 
     let provider_trait = derive_provider_trait(
-        &spec.component_name,
-        &spec.component_params,
+        component_name,
+        component_params,
         &consumer_trait,
         provider_name,
         context_type,
@@ -32,8 +36,17 @@ pub fn derive_component_with_ast(
         context_type,
         &consumer_trait,
         &provider_trait,
-        &spec.component_name,
-        &spec.component_params,
+        component_name,
+        component_params,
+    )?;
+
+    let use_context_impl = derive_use_context_impl(context_type, &consumer_trait, &provider_trait)?;
+
+    let use_context_is_provider_impl = derive_is_provider_for(
+        &parse2(quote! {
+            #component_name < #component_params >
+        })?,
+        &use_context_impl,
     )?;
 
     let derived = DerivedComponent {
@@ -42,6 +55,8 @@ pub fn derive_component_with_ast(
         provider_trait,
         consumer_impl,
         provider_impl,
+        use_context_impl,
+        use_context_is_provider_impl,
     };
 
     Ok(derived)
@@ -53,6 +68,8 @@ pub struct DerivedComponent {
     pub provider_trait: ItemTrait,
     pub consumer_impl: ItemImpl,
     pub provider_impl: ItemImpl,
+    pub use_context_impl: ItemImpl,
+    pub use_context_is_provider_impl: ItemImpl,
 }
 
 impl ToTokens for DerivedComponent {
@@ -62,5 +79,7 @@ impl ToTokens for DerivedComponent {
         self.provider_trait.to_tokens(tokens);
         self.consumer_impl.to_tokens(tokens);
         self.provider_impl.to_tokens(tokens);
+        self.use_context_impl.to_tokens(tokens);
+        self.use_context_is_provider_impl.to_tokens(tokens);
     }
 }

--- a/crates/cgp-macro-lib/src/derive_component/mod.rs
+++ b/crates/cgp-macro-lib/src/derive_component/mod.rs
@@ -9,6 +9,7 @@ mod replace_self_receiver;
 mod replace_self_type;
 mod signature_args;
 mod snake_case;
+mod use_context_impl;
 
 pub use derive::*;
 pub use replace_self_type::*;

--- a/crates/cgp-macro-lib/src/derive_component/signature_args.rs
+++ b/crates/cgp-macro-lib/src/derive_component/signature_args.rs
@@ -1,22 +1,14 @@
 use proc_macro2::Span;
-use syn::punctuated::Punctuated;
-use syn::token::Comma;
 use syn::{parse_quote, FnArg, Ident, Signature};
 
-pub fn signature_to_args(sig: &Signature) -> Punctuated<Ident, Comma> {
-    let args = sig
-        .inputs
-        .iter()
-        .map(|arg| -> Ident {
-            match arg {
-                FnArg::Receiver(_) => Ident::new("self", Span::call_site()),
-                FnArg::Typed(pat) => {
-                    let ident_pat = &pat.pat;
-                    parse_quote!( #ident_pat )
-                }
+pub fn signature_to_args(sig: &Signature) -> impl Iterator<Item = Ident> + '_ {
+    sig.inputs.iter().map(|arg| -> Ident {
+        match arg {
+            FnArg::Receiver(_) => Ident::new("self", Span::call_site()),
+            FnArg::Typed(pat) => {
+                let ident_pat = &pat.pat;
+                parse_quote!( #ident_pat )
             }
-        })
-        .collect();
-
-    args
+        }
+    })
 }

--- a/crates/cgp-macro-lib/src/derive_component/use_context_impl.rs
+++ b/crates/cgp-macro-lib/src/derive_component/use_context_impl.rs
@@ -1,0 +1,88 @@
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::token::{Brace, For, Impl};
+use syn::{parse2, Error, GenericParam, Ident, ImplItem, ItemImpl, ItemTrait, Path, TraitItem};
+
+use crate::derive_component::delegate_fn::derive_delegated_fn_impl;
+use crate::derive_component::delegate_type::derive_delegate_type_impl;
+use crate::parse::TypeGenerics;
+
+pub fn derive_use_context_impl(
+    context_type: &Ident,
+    consumer_trait: &ItemTrait,
+    provider_trait: &ItemTrait,
+) -> syn::Result<ItemImpl> {
+    let consumer_trait_ident = &consumer_trait.ident;
+    let provider_trait_ident = &provider_trait.ident;
+
+    let provider_generics = TypeGenerics::try_from(&provider_trait.generics)?.generics;
+
+    let consumer_generics = TypeGenerics::try_from(&consumer_trait.generics)?.generics;
+
+    let mut impl_generics = provider_trait.generics.clone();
+
+    let where_clause = impl_generics.make_where_clause();
+
+    where_clause.predicates.push(parse2(quote! {
+        #context_type : #consumer_trait_ident #consumer_generics
+    })?);
+
+    let mut impl_items: Vec<ImplItem> = Vec::new();
+
+    for trait_item in provider_trait.items.iter() {
+        match &trait_item {
+            TraitItem::Fn(trait_fn) => {
+                let impl_fn = derive_delegated_fn_impl(&trait_fn.sig, &quote!( #context_type ))?;
+
+                impl_items.push(ImplItem::Fn(impl_fn))
+            }
+            TraitItem::Type(trait_type) => {
+                let type_name = &trait_type.ident;
+
+                let type_generics = {
+                    let mut type_generics = trait_type.generics.clone();
+                    type_generics.where_clause = None;
+
+                    for param in &mut type_generics.params {
+                        if let GenericParam::Type(type_param) = param {
+                            type_param.bounds.clear();
+                        }
+                    }
+
+                    type_generics
+                };
+
+                let impl_type = derive_delegate_type_impl(
+                    trait_type,
+                    parse2(quote!(
+                        #context_type :: #type_name #type_generics
+                    ))?,
+                );
+
+                impl_items.push(ImplItem::Type(impl_type));
+            }
+            _ => {
+                return Err(Error::new(
+                    trait_item.span(),
+                    format!("unsupported trait item: {trait_item:?}"),
+                ))
+            }
+        }
+    }
+
+    let trait_path: Path = parse2(quote!( #provider_trait_ident #provider_generics ))?;
+
+    let item = ItemImpl {
+        attrs: provider_trait.attrs.clone(),
+        defaultness: None,
+        unsafety: provider_trait.unsafety,
+        impl_token: Impl::default(),
+        generics: impl_generics,
+        trait_: Some((None, trait_path, For::default())),
+        self_ty: Box::new(parse2(quote!(UseContext))?),
+        brace_token: Brace::default(),
+        items: impl_items,
+    };
+
+    Ok(item)
+}

--- a/crates/cgp-macro-lib/src/tests/derive_component.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_component.rs
@@ -76,6 +76,21 @@ fn test_derive_component_with_const_generic() {
                 Component::Delegate::foo(context)
             }
         }
+
+        impl<Context, const BAR: usize> FooProvider<Context, BAR> for UseContext
+        where
+            Context: HasFoo<BAR>,
+        {
+            type Foo = Context::Foo;
+            fn foo(context: &Context) -> Self::Foo {
+                Context::foo(context)
+            }
+        }
+        impl<Context, const BAR: usize> IsProviderFor<FooComponent, Context, (BAR)>
+        for UseContext
+        where
+            Context: HasFoo<BAR>,
+        {}
     };
 
     assert_equal_token_stream(&derived, &expected);

--- a/crates/cgp-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_getter.rs
@@ -54,6 +54,21 @@ fn test_derive_getter_basic() {
             }
         }
 
+        impl<Context> NameGetter<Context> for UseContext
+        where
+            Context: HasNameType,
+            Context: HasName,
+        {
+            fn name(context: &Context) -> &Context::Name {
+                Context::name(context)
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseContext
+        where
+            Context: HasNameType,
+            Context: HasName,
+        {}
+
         impl<Context> NameGetter<Context> for UseFields
         where
             Context: HasNameType,
@@ -161,6 +176,18 @@ fn test_derive_getter_str() {
                 Component::Delegate::name(context)
             }
         }
+        impl<Context> NameGetter<Context> for UseContext
+        where
+            Context: HasName,
+        {
+            fn name(context: &Context) -> &str {
+                Context::name(context)
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseContext
+        where
+            Context: HasName,
+        {}
         impl<Context> NameGetter<Context> for UseFields
         where
             Context: HasField<
@@ -257,6 +284,18 @@ fn test_derive_getter_mut_str() {
                 Component::Delegate::name(context)
             }
         }
+        impl<Context> NameGetter<Context> for UseContext
+        where
+            Context: HasName,
+        {
+            fn name(context: &mut Context) -> &mut str {
+                Context::name(context)
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseContext
+        where
+            Context: HasName,
+        {}
         impl<Context> NameGetter<Context> for UseFields
         where
             Context: HasFieldMut<
@@ -360,6 +399,20 @@ fn test_derive_getter_clone() {
                 Component::Delegate::name(context)
             }
         }
+        impl<Context> NameGetter<Context> for UseContext
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasName,
+        {
+            fn name(context: &Context) -> Context::Name {
+                Context::name(context)
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseContext
+        where
+            Context: HasNameType<Name: Clone>,
+            Context: HasName,
+        {}
         impl<Context> NameGetter<Context> for UseFields
         where
             Context: HasNameType<Name: Clone>,
@@ -469,6 +522,20 @@ fn test_derive_getter_option_ref() {
                 Component::Delegate::name(context)
             }
         }
+        impl<Context> NameGetter<Context> for UseContext
+        where
+            Context: HasNameType,
+            Context: HasName,
+        {
+            fn name(context: &Context) -> Option<&Context::Name> {
+                Context::name(context)
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseContext
+        where
+            Context: HasNameType,
+            Context: HasName,
+        {}
         impl<Context> NameGetter<Context> for UseFields
         where
             Context: HasNameType,
@@ -578,6 +645,20 @@ fn test_derive_getter_option_mut() {
                 Component::Delegate::name(context)
             }
         }
+        impl<Context> NameGetter<Context> for UseContext
+        where
+            Context: HasNameType,
+            Context: HasName,
+        {
+            fn name(context: &mut Context) -> Option<&mut Context::Name> {
+                Context::name(context)
+            }
+        }
+        impl<Context> IsProviderFor<NameGetterComponent, Context, ()> for UseContext
+        where
+            Context: HasNameType,
+            Context: HasName,
+        {}
         impl<Context> NameGetter<Context> for UseFields
         where
             Context: HasNameType,
@@ -697,7 +778,20 @@ fn test_derive_getter_with_generics() {
                 Component::Delegate::name(context)
             }
         }
-
+        impl<Context, App> NameGetter<Context, App> for UseContext
+        where
+            App: HasNameType,
+            Context: HasName<App>,
+        {
+            fn name(context: &Context) -> &App::Name {
+                Context::name(context)
+            }
+        }
+        impl<Context, App> IsProviderFor<NameGetterComponent, Context, (App)> for UseContext
+        where
+            App: HasNameType,
+            Context: HasName<App>,
+        {}
         impl<Context, App> NameGetter<Context, App> for UseFields
         where
             App: HasNameType,
@@ -818,6 +912,20 @@ fn test_derive_getter_with_component_generics() {
                 Component::Delegate::name(context)
             }
         }
+        impl<Context, App> NameGetter<Context, App> for UseContext
+        where
+            App: HasNameType,
+            Context: HasName<App>,
+        {
+            fn name(context: &Context) -> &App::Name {
+                Context::name(context)
+            }
+        }
+        impl<Context, App> IsProviderFor<NameGetterComponent<App>, Context, (App)> for UseContext
+        where
+            App: HasNameType,
+            Context: HasName<App>,
+        {}
         impl<Context, App> NameGetter<Context, App> for UseFields
         where
             App: HasNameType,
@@ -934,6 +1042,21 @@ fn test_derive_getter_with_phantom() {
                 Component::Delegate::name(context, _phantom)
             }
         }
+        impl<Context, App, B> NameGetter<Context, App, B> for UseContext
+        where
+            App: HasNameType,
+            Context: HasName<App, B>,
+        {
+            fn name(context: &Context, _phantom: PhantomData<(App, B)>) -> &App::Name {
+                Context::name(context, _phantom)
+            }
+        }
+        impl<Context, App, B> IsProviderFor<NameGetterComponent, Context, (App, B)>
+        for UseContext
+        where
+            App: HasNameType,
+            Context: HasName<App, B>,
+        {}
         impl<Context, App, B> NameGetter<Context, App, B> for UseFields
         where
             App: HasNameType,

--- a/crates/cgp-type/src/traits/has_type.rs
+++ b/crates/cgp-type/src/traits/has_type.rs
@@ -12,14 +12,6 @@ pub trait HasType<Tag> {
 pub type TypeOf<Context, Tag> = <Context as HasType<Tag>>::Type;
 
 #[cgp_provider(TypeComponent)]
-impl<Context, Tag> ProvideType<Context, Tag> for UseContext
-where
-    Context: HasType<Tag>,
-{
-    type Type = Context::Type;
-}
-
-#[cgp_provider(TypeComponent)]
 impl<Context, Tag, Components, Delegate> ProvideType<Context, Tag> for UseDelegate<Components>
 where
     Components: DelegateComponent<Tag, Delegate = Delegate>,


### PR DESCRIPTION
## Summary

This PR enhances the `#[cgp_component]` macro families to include an auto derivation of implementation of `UseContext`.

`UseContext` is used as a provider that simply delegates the implementation back to the context. It is the reverse of consumer-to-provider delegation.

As an example, given the following:

```rust
#[cgp_component {
    provider: NameGetter,
}]
pub trait HasName {
    fn name(&self) -> &str;
}
```

The following `UseContext` implementation would be derived:

```rust
impl<Context> NameGetter<Context> for UseContext
where
    Context: HasName,
{
    fn name(context: &Context) -> &str {
        context.name()
    }
}
```

The use of `UseContext` can be useful in the advanced CGP usage of higher-order providers, where providers are passed as type parameters directly to other providers. The auto derivation of `UseContext` will make it simpler to make use of higher-order provider patterns, without needing to explicitly derive the implementation on all relevant CGP traits.