### PR TITLE
Fix nested inheritance and multi inheritance for presets

### DIFF
--- a/crates/cgp-macro-lib/src/entrypoints/cgp_preset.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_preset.rs
@@ -47,7 +47,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         let mut overrides: Punctuated<&Ident, Comma> = Punctuated::default();
 
         for entry in ast.delegate_entries.iter() {
-            if entry.is_override {
+            if entry.is_override.is_some() {
                 for component in entry.entry.components.iter() {
                     overrides.push(&component.component_type.name);
                 }
@@ -62,6 +62,8 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
             TokenStream::new()
         };
 
+        let preset_entries = &ast.delegate_entries;
+
         let output = quote! {
             use #parent_ident ::components::*;
 
@@ -71,7 +73,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
                     cgp_preset! {
                         #preset_type_spec: #parent_presets {
                             #parent_components_ident: #parent_ident :: Provider #parent_generics,
-                            #delegate_entries
+                            #preset_entries
                         }
                     }
                 }

--- a/crates/cgp-macro-lib/src/parse/define_preset.rs
+++ b/crates/cgp-macro-lib/src/parse/define_preset.rs
@@ -14,7 +14,7 @@ pub struct DefinePreset {
 }
 
 pub struct DelegatePresetEntry {
-    pub is_override: bool,
+    pub is_override: Option<Override>,
     pub entry: DelegateComponentEntry<SimpleType>,
 }
 
@@ -42,10 +42,10 @@ impl Parse for DefinePreset {
 impl Parse for DelegatePresetEntry {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let is_override = if input.peek(Override) {
-            let _: Override = input.parse()?;
-            true
+            let is_override = input.parse()?;
+            Some(is_override)
         } else {
-            false
+            None
         };
 
         let entry = input.parse()?;
@@ -69,6 +69,13 @@ impl Parse for PresetParent {
             has_expanded,
             parent_type,
         })
+    }
+}
+
+impl ToTokens for DelegatePresetEntry {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.is_override.to_tokens(tokens);
+        self.entry.to_tokens(tokens);
     }
 }
 

--- a/crates/cgp-tests/src/tests/preset/nested_inheritance/preset_b.rs
+++ b/crates/cgp-tests/src/tests/preset/nested_inheritance/preset_b.rs
@@ -2,13 +2,14 @@
 mod preset {
     use cgp::prelude::*;
 
-    use crate::tests::preset::basic::components::FooGetterComponent;
+    use crate::tests::preset::basic::components::{BarTypeProviderComponent, FooGetterComponent};
     use crate::tests::preset::nested_inheritance::preset_a::NestedPresetA;
 
     cgp_preset! {
         NestedPresetB: NestedPresetA {
             override FooGetterComponent:
                 UseField<symbol!("food")>,
+            BarTypeProviderComponent: UseType<()>,
         }
     }
 

--- a/crates/cgp-tests/src/tests/preset/nested_inheritance/preset_d.rs
+++ b/crates/cgp-tests/src/tests/preset/nested_inheritance/preset_d.rs
@@ -9,6 +9,8 @@ mod preset {
         NestedPresetD: NestedPresetB + NestedPresetC {
             override FooGetterComponent:
                 UseField<symbol!("fool")>,
+            override BarTypeProviderComponent:
+                NestedPresetC::Provider,
         }
     }
 


### PR DESCRIPTION
## Summary

This is a small follow up on #91 to fix the support of nested and multiple inheritance of presets. In the previous PR, I missed re-propagating the `override` flag on the preset entries, when re-expanding the macros to support inheritance.