### PR TITLE
Allow definition of new structs inside `delegate_components!`

### DIFF
--- a/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
+++ b/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
@@ -25,7 +25,7 @@ where
     for entry in delegate_entries.iter() {
         let source = &entry.value;
         for component in entry.keys.iter() {
-            let impls = impl_delegate_component(target_type, target_generics, component, &source)?;
+            let impls = impl_delegate_component(target_type, target_generics, component, source)?;
 
             out.extend(impls);
         }
@@ -102,7 +102,7 @@ where
     if let DelegateValue::New(value) = value {
         let struct_ident = &value.struct_ident;
 
-        let item_struct = define_struct(&struct_ident, &value.struct_generics)?;
+        let item_struct = define_struct(struct_ident, &value.struct_generics)?;
 
         let (impl_generics, type_generics, _) = value.struct_generics.split_for_impl();
 

--- a/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
+++ b/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
@@ -8,12 +8,12 @@ use syn::token::Comma;
 use syn::{parse2, ImplItem, ImplItemType, ItemImpl, Path, Type};
 
 use crate::delegate_components::merge_generics::merge_generics;
-use crate::parse::{DelegateComponentEntry, DelegateComponentName, ImplGenerics};
+use crate::parse::{DelegateEntry, DelegateKey, ImplGenerics};
 
 pub fn impl_delegate_components<T>(
     target_type: &Type,
     target_generics: &ImplGenerics,
-    delegate_entries: &Punctuated<DelegateComponentEntry<T>, Comma>,
+    delegate_entries: &Punctuated<DelegateEntry<T>, Comma>,
 ) -> syn::Result<Vec<ItemImpl>>
 where
     T: ToTokens,
@@ -21,8 +21,8 @@ where
     let mut components = Vec::new();
 
     for entry in delegate_entries.iter() {
-        let source = &entry.source;
-        for component in entry.components.iter() {
+        let source = &entry.value;
+        for component in entry.keys.iter() {
             let mut impls =
                 impl_delegate_component(target_type, target_generics, component, source)?;
             components.append(&mut impls);
@@ -35,22 +35,19 @@ where
 pub fn impl_delegate_component<T>(
     target_type: &Type,
     target_generics: &ImplGenerics,
-    component: &DelegateComponentName<T>,
+    component: &DelegateKey<T>,
     source: &Type,
 ) -> syn::Result<Vec<ItemImpl>>
 where
     T: ToTokens,
 {
-    let component_type = &component.component_type;
+    let component_type = &component.ty;
 
     let delegate_trait_path: Path = parse2(quote!(DelegateComponent < #component_type >))?;
 
     let delegate_type: ImplItemType = parse2(quote!(type Delegate = #source;))?;
 
-    let delegate_generics = merge_generics(
-        &target_generics.generics,
-        &component.component_generics.generics,
-    );
+    let delegate_generics = merge_generics(&target_generics.generics, &component.generics.generics);
 
     let is_provider_generics = {
         let mut generics = delegate_generics.clone();

--- a/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
+++ b/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
@@ -8,8 +8,9 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{parse2, ImplItem, ImplItemType, ItemImpl, Path, Type};
 
+use crate::delegate_components::define_struct;
 use crate::delegate_components::merge_generics::merge_generics;
-use crate::parse::{DelegateEntry, DelegateKey, ImplGenerics};
+use crate::parse::{DelegateEntry, DelegateKey, DelegateValue, ImplGenerics};
 
 pub fn impl_delegate_components<T>(
     target_type: &Type,
@@ -24,12 +25,7 @@ where
     for entry in delegate_entries.iter() {
         let source = &entry.value;
         for component in entry.keys.iter() {
-            let impls = impl_delegate_component(
-                target_type,
-                target_generics,
-                component,
-                &source.as_type(),
-            )?;
+            let impls = impl_delegate_component(target_type, target_generics, component, &source)?;
 
             out.extend(impls);
         }
@@ -42,16 +38,18 @@ pub fn impl_delegate_component<T>(
     target_type: &Type,
     target_generics: &ImplGenerics,
     component: &DelegateKey<T>,
-    source: &Type,
+    value: &DelegateValue,
 ) -> syn::Result<TokenStream>
 where
     T: ToTokens,
 {
     let component_type = &component.ty;
 
+    let value_type = value.as_type();
+
     let delegate_trait_path: Path = parse2(quote!(DelegateComponent < #component_type >))?;
 
-    let delegate_type: ImplItemType = parse2(quote!(type Delegate = #source;))?;
+    let delegate_type: ImplItemType = parse2(quote!(type Delegate = #value_type;))?;
 
     let delegate_generics = merge_generics(&target_generics.generics, &component.generics.generics);
 
@@ -63,7 +61,7 @@ where
 
         let where_clause = generics.make_where_clause();
         where_clause.predicates.push(parse2(
-            quote!( #source : IsProviderFor< #component_type, __Context__, __Params__ > ),
+            quote!( #value_type : IsProviderFor< #component_type, __Context__, __Params__ > ),
         )?);
 
         generics
@@ -96,8 +94,27 @@ where
         items: Default::default(),
     };
 
-    Ok(quote! {
+    let mut out = quote! {
         #delegate_impl
         #is_provider_impl
-    })
+    };
+
+    if let DelegateValue::New(value) = value {
+        let struct_ident = &value.struct_ident;
+
+        let item_struct = define_struct(&struct_ident, &value.struct_generics)?;
+
+        let (impl_generics, type_generics, _) = value.struct_generics.split_for_impl();
+
+        let target_type: Type = parse2(quote! { #struct_ident #type_generics })?;
+
+        let impl_generics = parse2(quote! { #impl_generics })?;
+
+        let inner_impls = impl_delegate_components(&target_type, &impl_generics, &value.entries)?;
+
+        out.extend(item_struct.to_token_stream());
+        out.extend(inner_impls);
+    }
+
+    Ok(out)
 }

--- a/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
+++ b/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
@@ -14,27 +15,27 @@ pub fn impl_delegate_components<T>(
     target_type: &Type,
     target_generics: &ImplGenerics,
     delegate_entries: &Punctuated<DelegateEntry<T>, Comma>,
-) -> syn::Result<Vec<ItemImpl>>
+) -> syn::Result<TokenStream>
 where
     T: ToTokens,
 {
-    let mut components = Vec::new();
+    let mut out = TokenStream::new();
 
     for entry in delegate_entries.iter() {
         let source = &entry.value;
         for component in entry.keys.iter() {
-            let mut impls = impl_delegate_component(
+            let impls = impl_delegate_component(
                 target_type,
                 target_generics,
                 component,
                 &source.as_type(),
             )?;
 
-            components.append(&mut impls);
+            out.extend(impls);
         }
     }
 
-    Ok(components)
+    Ok(out)
 }
 
 pub fn impl_delegate_component<T>(
@@ -42,7 +43,7 @@ pub fn impl_delegate_component<T>(
     target_generics: &ImplGenerics,
     component: &DelegateKey<T>,
     source: &Type,
-) -> syn::Result<Vec<ItemImpl>>
+) -> syn::Result<TokenStream>
 where
     T: ToTokens,
 {
@@ -95,5 +96,8 @@ where
         items: Default::default(),
     };
 
-    Ok(vec![delegate_impl, is_provider_impl])
+    Ok(quote! {
+        #delegate_impl
+        #is_provider_impl
+    })
 }

--- a/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
+++ b/crates/cgp-macro-lib/src/delegate_components/impl_delegate.rs
@@ -23,8 +23,13 @@ where
     for entry in delegate_entries.iter() {
         let source = &entry.value;
         for component in entry.keys.iter() {
-            let mut impls =
-                impl_delegate_component(target_type, target_generics, component, source)?;
+            let mut impls = impl_delegate_component(
+                target_type,
+                target_generics,
+                component,
+                &source.as_type(),
+            )?;
+
             components.append(&mut impls);
         }
     }

--- a/crates/cgp-macro-lib/src/entrypoints/cgp_preset.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_preset.rs
@@ -8,13 +8,13 @@ use syn::{parse2, parse_quote, Ident, ItemTrait};
 
 use crate::delegate_components::{define_struct, impl_delegate_components};
 use crate::derive_component::to_snake_case_str;
-use crate::parse::{DefinePreset, DelegateComponentEntry, ImplGenerics, SimpleType};
+use crate::parse::{DefinePreset, DelegateEntry, ImplGenerics, SimpleType};
 use crate::preset::{define_substitution_macro, impl_components_is_preset};
 
 pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
     let ast: DefinePreset = syn::parse2(body)?;
 
-    let delegate_entries: Punctuated<DelegateComponentEntry<SimpleType>, Comma> = ast
+    let delegate_entries: Punctuated<DelegateEntry<SimpleType>, Comma> = ast
         .delegate_entries
         .iter()
         .map(|entry| entry.entry.clone())
@@ -48,8 +48,8 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
         for entry in ast.delegate_entries.iter() {
             if entry.is_override.is_some() {
-                for component in entry.entry.components.iter() {
-                    overrides.push(&component.component_type.name);
+                for component in entry.entry.keys.iter() {
+                    overrides.push(&component.ty.name);
                 }
             }
         }
@@ -145,7 +145,7 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
 
         let all_components: Punctuated<_, Comma> = delegate_entries
             .iter()
-            .flat_map(|entry| entry.components.clone().into_iter())
+            .flat_map(|entry| entry.keys.clone().into_iter())
             .collect();
 
         let with_components_macro = define_substitution_macro(
@@ -189,8 +189,8 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
         let mut components: HashSet<Ident> = HashSet::default();
 
         for entry in delegate_entries.iter() {
-            for component in entry.components.iter() {
-                let component_name = &component.component_type.name;
+            for component in entry.keys.iter() {
+                let component_name = &component.ty.name;
                 components.insert(component_name.clone());
             }
         }

--- a/crates/cgp-macro-lib/src/entrypoints/cgp_preset.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_preset.rs
@@ -177,8 +177,11 @@ pub fn define_preset(body: TokenStream) -> syn::Result<TokenStream> {
             mod re_exports {
                 #[doc(hidden)]
                 #[doc(no_inline)]
-                #[allow(unused_imports)]
                 pub use super::super::super::re_exports::*;
+
+                #[doc(hidden)]
+                #[doc(no_inline)]
+                pub use super::super::*;
 
                 #parent_exports
             }

--- a/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
@@ -7,18 +7,23 @@ use crate::parse::{DelegateComponents, SimpleType};
 
 pub fn delegate_components(body: TokenStream) -> syn::Result<TokenStream> {
     let spec: DelegateComponents = parse2(body)?;
+    let mut target_generics = spec.target_generics;
 
     let component_struct = if spec.new_struct {
         let target_type: SimpleType<Generics> = parse2(spec.target_type.to_token_stream())?;
-        let component_struct =
-            define_struct(&target_type.name, &target_type.generics.unwrap_or_default())?;
+
+        let type_generics = target_type.generics.unwrap_or_default();
+
+        let component_struct = define_struct(&target_type.name, &type_generics)?;
+
+        target_generics.generics.params.extend(type_generics.params);
+
         Some(component_struct)
     } else {
         None
     };
 
-    let impl_items =
-        impl_delegate_components(&spec.target_type, &spec.target_generics, &spec.entries)?;
+    let impl_items = impl_delegate_components(&spec.target_type, &target_generics, &spec.entries)?;
 
     let mut output = quote! {
         #component_struct

--- a/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
@@ -7,11 +7,8 @@ use crate::parse::DelegateComponents;
 pub fn delegate_components(body: TokenStream) -> syn::Result<TokenStream> {
     let ast: DelegateComponents = syn::parse2(body)?;
 
-    let impl_items = impl_delegate_components(
-        &ast.target_type,
-        &ast.target_generics,
-        &ast.delegate_entries,
-    )?;
+    let impl_items =
+        impl_delegate_components(&ast.target_type, &ast.target_generics, &ast.entries)?;
 
     let mut output = TokenStream::new();
 

--- a/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
@@ -1,18 +1,18 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{parse2, Generics};
+use syn::parse2;
 
 use crate::delegate_components::{define_struct, impl_delegate_components};
-use crate::parse::{DelegateComponents, SimpleType};
+use crate::parse::{DelegateComponents, SimpleType, TypeGenerics};
 
 pub fn delegate_components(body: TokenStream) -> syn::Result<TokenStream> {
     let spec: DelegateComponents = parse2(body)?;
     let mut target_generics = spec.target_generics;
 
     let component_struct = if spec.new_struct {
-        let target_type: SimpleType<Generics> = parse2(spec.target_type.to_token_stream())?;
+        let target_type: SimpleType<TypeGenerics> = parse2(spec.target_type.to_token_stream())?;
 
-        let type_generics = target_type.generics.unwrap_or_default();
+        let type_generics = target_type.generics.unwrap_or_default().generics;
 
         let component_struct = define_struct(&target_type.name, &type_generics)?;
 

--- a/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
@@ -1,16 +1,28 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
+use syn::{parse2, Generics};
 
-use crate::delegate_components::impl_delegate_components;
-use crate::parse::DelegateComponents;
+use crate::delegate_components::{define_struct, impl_delegate_components};
+use crate::parse::{DelegateComponents, SimpleType};
 
 pub fn delegate_components(body: TokenStream) -> syn::Result<TokenStream> {
-    let ast: DelegateComponents = syn::parse2(body)?;
+    let spec: DelegateComponents = parse2(body)?;
+
+    let component_struct = if spec.new_struct.is_some() {
+        let target_type: SimpleType<Generics> = parse2(spec.target_type.to_token_stream())?;
+        let component_struct =
+            define_struct(&target_type.name, &target_type.generics.unwrap_or_default())?;
+        Some(component_struct)
+    } else {
+        None
+    };
 
     let impl_items =
-        impl_delegate_components(&ast.target_type, &ast.target_generics, &ast.entries)?;
+        impl_delegate_components(&spec.target_type, &spec.target_generics, &spec.entries)?;
 
-    let mut output = TokenStream::new();
+    let mut output = quote! {
+        #component_struct
+    };
 
     for impl_item in impl_items {
         output.extend(impl_item.to_token_stream());

--- a/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/delegate_components.rs
@@ -8,7 +8,7 @@ use crate::parse::{DelegateComponents, SimpleType};
 pub fn delegate_components(body: TokenStream) -> syn::Result<TokenStream> {
     let spec: DelegateComponents = parse2(body)?;
 
-    let component_struct = if spec.new_struct.is_some() {
+    let component_struct = if spec.new_struct {
         let target_type: SimpleType<Generics> = parse2(spec.target_type.to_token_stream())?;
         let component_struct =
             define_struct(&target_type.name, &target_type.generics.unwrap_or_default())?;

--- a/crates/cgp-macro-lib/src/for_each_replace.rs
+++ b/crates/cgp-macro-lib/src/for_each_replace.rs
@@ -9,7 +9,7 @@ use syn::punctuated::Punctuated;
 use syn::token::{Comma, Or};
 use syn::{braced, Ident};
 
-use crate::parse::{DelegateComponentName, SimpleType};
+use crate::parse::{DelegateKey, SimpleType};
 
 pub struct ReplaceSpecs {
     pub target_ident: Ident,
@@ -19,10 +19,9 @@ pub struct ReplaceSpecs {
 
 impl Parse for ReplaceSpecs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let raw_replacements: Vec<DelegateComponentName<SimpleType>> = {
+        let raw_replacements: Vec<DelegateKey<SimpleType>> = {
             let content = parse_brackets(input)?.content;
-            let types =
-                <Punctuated<DelegateComponentName<SimpleType>, Comma>>::parse_terminated(&content)?;
+            let types = <Punctuated<DelegateKey<SimpleType>, Comma>>::parse_terminated(&content)?;
             types.into_iter().collect()
         };
 
@@ -59,7 +58,7 @@ impl Parse for ReplaceSpecs {
         let replacements = raw_replacements
             .into_iter()
             .filter(|replacement| {
-                let target_ident = &replacement.component_type.name;
+                let target_ident = &replacement.ty.name;
 
                 exclude.iter().all(|exclude| exclude != target_ident)
             })

--- a/crates/cgp-macro-lib/src/parse/define_preset.rs
+++ b/crates/cgp-macro-lib/src/parse/define_preset.rs
@@ -5,7 +5,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::{At, Colon, Comma, Override, Plus};
 
-use crate::parse::{DelegateComponentEntry, SimpleType, TypeSpec};
+use crate::parse::{DelegateEntry, SimpleType, TypeSpec};
 
 pub struct DefinePreset {
     pub preset: TypeSpec,
@@ -15,7 +15,7 @@ pub struct DefinePreset {
 
 pub struct DelegatePresetEntry {
     pub is_override: Option<Override>,
-    pub entry: DelegateComponentEntry<SimpleType>,
+    pub entry: DelegateEntry<SimpleType>,
 }
 
 impl Parse for DefinePreset {

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -4,12 +4,13 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::token::{Bracket, Colon, Comma, Lt};
+use syn::token::{Bracket, Colon, Comma, Lt, Struct};
 use syn::{braced, bracketed, Token, Type};
 
 use crate::parse::ImplGenerics;
 
 pub struct DelegateComponents {
+    pub new_struct: Option<Struct>,
     pub target_type: Type,
     pub target_generics: ImplGenerics,
     pub entries: Punctuated<DelegateEntry<Type>, Comma>,
@@ -35,6 +36,12 @@ impl Parse for DelegateComponents {
             Default::default()
         };
 
+        let new_struct = if input.peek(Struct) {
+            Some(input.parse()?)
+        } else {
+            None
+        };
+
         let target_type: Type = input.parse()?;
 
         let delegate_entries = {
@@ -44,6 +51,7 @@ impl Parse for DelegateComponents {
         };
 
         Ok(Self {
+            new_struct,
             target_type,
             target_generics,
             entries: delegate_entries,

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -8,7 +8,7 @@ use syn::punctuated::Punctuated;
 use syn::token::{Bracket, Colon, Comma, Gt, Lt};
 use syn::{braced, bracketed, parse_quote, Error, Generics, Ident, Token, Type};
 
-use crate::parse::ImplGenerics;
+use crate::parse::{ImplGenerics, TypeGenerics};
 
 pub struct DelegateComponents {
     pub new_struct: bool,
@@ -167,7 +167,7 @@ impl Parse for DelegateNewValue {
 
         let struct_ident = input.parse()?;
 
-        let struct_generics = input.parse()?;
+        let struct_generics: TypeGenerics = input.parse()?;
 
         let entries = {
             let content;
@@ -181,7 +181,7 @@ impl Parse for DelegateNewValue {
         Ok(Self {
             wrapper_ident,
             struct_ident,
-            struct_generics,
+            struct_generics: struct_generics.generics,
             entries,
         })
     }

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -12,19 +12,19 @@ use crate::parse::ImplGenerics;
 pub struct DelegateComponents {
     pub target_type: Type,
     pub target_generics: ImplGenerics,
-    pub delegate_entries: Punctuated<DelegateComponentEntry<Type>, Comma>,
+    pub entries: Punctuated<DelegateEntry<Type>, Comma>,
 }
 
 #[derive(Clone)]
-pub struct DelegateComponentEntry<T> {
-    pub components: Punctuated<DelegateComponentName<T>, Comma>,
-    pub source: Type,
+pub struct DelegateEntry<T> {
+    pub keys: Punctuated<DelegateKey<T>, Comma>,
+    pub value: Type,
 }
 
 #[derive(Clone)]
-pub struct DelegateComponentName<T> {
-    pub component_type: T,
-    pub component_generics: ImplGenerics,
+pub struct DelegateKey<T> {
+    pub ty: T,
+    pub generics: ImplGenerics,
 }
 
 impl Parse for DelegateComponents {
@@ -46,12 +46,12 @@ impl Parse for DelegateComponents {
         Ok(Self {
             target_type,
             target_generics,
-            delegate_entries,
+            entries: delegate_entries,
         })
     }
 }
 
-impl<Type> Parse for DelegateComponentEntry<Type>
+impl<Type> Parse for DelegateEntry<Type>
 where
     Type: Parse,
 {
@@ -59,9 +59,9 @@ where
         let components = if input.peek(Bracket) {
             let components_body;
             bracketed!(components_body in input);
-            components_body.parse_terminated(DelegateComponentName::parse, Token![,])?
+            components_body.parse_terminated(DelegateKey::parse, Token![,])?
         } else {
-            let component: DelegateComponentName<Type> = input.parse()?;
+            let component: DelegateKey<Type> = input.parse()?;
             Punctuated::from_iter(iter::once(component))
         };
 
@@ -69,11 +69,14 @@ where
 
         let source = input.parse()?;
 
-        Ok(Self { components, source })
+        Ok(Self {
+            keys: components,
+            value: source,
+        })
     }
 }
 
-impl<Type> Parse for DelegateComponentName<Type>
+impl<Type> Parse for DelegateKey<Type>
 where
     Type: Parse,
 {
@@ -87,19 +90,19 @@ where
         let component_type: Type = input.parse()?;
 
         Ok(Self {
-            component_type,
-            component_generics,
+            ty: component_type,
+            generics: component_generics,
         })
     }
 }
 
-impl<Type> ToTokens for DelegateComponentEntry<Type>
+impl<Type> ToTokens for DelegateEntry<Type>
 where
     Type: ToTokens,
 {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let components = &self.components;
-        let source = &self.source;
+        let components = &self.keys;
+        let source = &self.value;
 
         let count = components.len();
 
@@ -118,12 +121,12 @@ where
     }
 }
 
-impl<Type> ToTokens for DelegateComponentName<Type>
+impl<Type> ToTokens for DelegateKey<Type>
 where
     Type: ToTokens,
 {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(self.component_generics.to_token_stream());
-        tokens.extend(self.component_type.to_token_stream());
+        tokens.extend(self.generics.to_token_stream());
+        tokens.extend(self.ty.to_token_stream());
     }
 }

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -5,7 +5,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::discouraged::Speculative;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::token::{Bracket, Colon, Comma, Lt, Struct};
+use syn::token::{Bracket, Colon, Comma, Gt, Lt, Struct};
 use syn::{braced, bracketed, parse_quote, Generics, Ident, Token, Type};
 
 use crate::parse::ImplGenerics;
@@ -20,7 +20,7 @@ pub struct DelegateComponents {
 #[derive(Clone)]
 pub struct DelegateEntry<T> {
     pub keys: Punctuated<DelegateKey<T>, Comma>,
-    pub value: Type,
+    pub value: DelegateValue,
 }
 
 #[derive(Clone)]
@@ -29,6 +29,7 @@ pub struct DelegateKey<T> {
     pub generics: ImplGenerics,
 }
 
+#[derive(Clone)]
 pub enum DelegateValue {
     Type(Type),
     New(DelegateNewValue),
@@ -47,9 +48,10 @@ impl DelegateValue {
         match self {
             Self::Type(ty) => ty.clone(),
             Self::New(value) => {
+                let wrapper_ident = &value.wrapper_ident;
                 let struct_ident = &value.struct_ident;
                 let (_, struct_generics, _) = value.struct_generics.split_for_impl();
-                parse_quote!( #struct_ident #struct_generics )
+                parse_quote!( #wrapper_ident < #struct_ident #struct_generics > )
             }
         }
     }
@@ -163,6 +165,8 @@ impl Parse for DelegateNewValue {
 
             Punctuated::parse_terminated(&content)?
         };
+
+        let _: Gt = input.parse()?;
 
         Ok(Self {
             wrapper_ident,

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -2,10 +2,11 @@ use core::iter;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
+use syn::parse::discouraged::Speculative;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::{Bracket, Colon, Comma, Lt, Struct};
-use syn::{braced, bracketed, Generics, Ident, Token, Type};
+use syn::{braced, bracketed, parse_quote, Generics, Ident, Token, Type};
 
 use crate::parse::ImplGenerics;
 
@@ -28,11 +29,30 @@ pub struct DelegateKey<T> {
     pub generics: ImplGenerics,
 }
 
+pub enum DelegateValue {
+    Type(Type),
+    New(DelegateNewValue),
+}
+
+#[derive(Clone)]
 pub struct DelegateNewValue {
     pub wrapper_ident: Ident,
     pub struct_ident: Ident,
     pub struct_generics: Generics,
     pub entries: Punctuated<DelegateEntry<Type>, Comma>,
+}
+
+impl DelegateValue {
+    pub fn as_type(&self) -> Type {
+        match self {
+            Self::Type(ty) => ty.clone(),
+            Self::New(value) => {
+                let struct_ident = &value.struct_ident;
+                let (_, struct_generics, _) = value.struct_generics.split_for_impl();
+                parse_quote!( #struct_ident #struct_generics )
+            }
+        }
+    }
 }
 
 impl Parse for DelegateComponents {
@@ -111,6 +131,20 @@ where
     }
 }
 
+impl Parse for DelegateValue {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let fork = input.fork();
+
+        match fork.parse::<DelegateNewValue>() {
+            Ok(value) => {
+                input.advance_to(&fork);
+                Ok(Self::New(value))
+            }
+            _ => Ok(Self::Type(input.parse()?)),
+        }
+    }
+}
+
 impl Parse for DelegateNewValue {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let wrapper_ident = input.parse()?;
@@ -171,6 +205,15 @@ where
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(self.generics.to_token_stream());
         tokens.extend(self.ty.to_token_stream());
+    }
+}
+
+impl ToTokens for DelegateValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Type(value) => value.to_tokens(tokens),
+            Self::New(value) => value.to_tokens(tokens),
+        }
     }
 }
 

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -5,7 +5,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::{Bracket, Colon, Comma, Lt, Struct};
-use syn::{braced, bracketed, Token, Type};
+use syn::{braced, bracketed, Generics, Ident, Token, Type};
 
 use crate::parse::ImplGenerics;
 
@@ -26,6 +26,13 @@ pub struct DelegateEntry<T> {
 pub struct DelegateKey<T> {
     pub ty: T,
     pub generics: ImplGenerics,
+}
+
+pub struct DelegateNewValue {
+    pub wrapper_ident: Ident,
+    pub struct_ident: Ident,
+    pub struct_generics: Generics,
+    pub entries: Punctuated<DelegateEntry<Type>, Comma>,
 }
 
 impl Parse for DelegateComponents {
@@ -104,6 +111,34 @@ where
     }
 }
 
+impl Parse for DelegateNewValue {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let wrapper_ident = input.parse()?;
+
+        let _: Lt = input.parse()?;
+
+        let _: Struct = input.parse()?;
+
+        let struct_ident = input.parse()?;
+
+        let struct_generics = input.parse()?;
+
+        let entries = {
+            let content;
+            braced!(content in input);
+
+            Punctuated::parse_terminated(&content)?
+        };
+
+        Ok(Self {
+            wrapper_ident,
+            struct_ident,
+            struct_generics,
+            entries,
+        })
+    }
+}
+
 impl<Type> ToTokens for DelegateEntry<Type>
 where
     Type: ToTokens,
@@ -136,5 +171,24 @@ where
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(self.generics.to_token_stream());
         tokens.extend(self.ty.to_token_stream());
+    }
+}
+
+impl ToTokens for DelegateNewValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self {
+            wrapper_ident,
+            struct_ident,
+            struct_generics,
+            entries,
+        } = self;
+
+        tokens.extend(quote! {
+            #wrapper_ident <
+                struct #struct_ident #struct_generics {
+                    #entries
+                }
+            >
+        });
     }
 }

--- a/crates/cgp-macro-lib/src/parse/delegate_components.rs
+++ b/crates/cgp-macro-lib/src/parse/delegate_components.rs
@@ -5,13 +5,13 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::discouraged::Speculative;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::token::{Bracket, Colon, Comma, Gt, Lt, Struct};
-use syn::{braced, bracketed, parse_quote, Generics, Ident, Token, Type};
+use syn::token::{Bracket, Colon, Comma, Gt, Lt};
+use syn::{braced, bracketed, parse_quote, Error, Generics, Ident, Token, Type};
 
 use crate::parse::ImplGenerics;
 
 pub struct DelegateComponents {
-    pub new_struct: Option<Struct>,
+    pub new_struct: bool,
     pub target_type: Type,
     pub target_generics: ImplGenerics,
     pub entries: Punctuated<DelegateEntry<Type>, Comma>,
@@ -65,10 +65,16 @@ impl Parse for DelegateComponents {
             Default::default()
         };
 
-        let new_struct = if input.peek(Struct) {
-            Some(input.parse()?)
-        } else {
-            None
+        let new_struct = {
+            let fork = input.fork();
+            let new_ident: Option<Ident> = fork.parse().ok();
+            match new_ident {
+                Some(new_ident) if new_ident == "new" => {
+                    input.advance_to(&fork);
+                    true
+                }
+                _ => false,
+            }
         };
 
         let target_type: Type = input.parse()?;
@@ -153,7 +159,11 @@ impl Parse for DelegateNewValue {
 
         let _: Lt = input.parse()?;
 
-        let _: Struct = input.parse()?;
+        let new_ident: Ident = input.parse()?;
+
+        if new_ident != "new" {
+            return Err(Error::new(new_ident.span(), "expect `new` keyword"));
+        }
 
         let struct_ident = input.parse()?;
 
@@ -232,7 +242,7 @@ impl ToTokens for DelegateNewValue {
 
         tokens.extend(quote! {
             #wrapper_ident <
-                struct #struct_ident #struct_generics {
+                new #struct_ident #struct_generics {
                     #entries
                 }
             >

--- a/crates/cgp-macro-lib/src/parse/simple_type.rs
+++ b/crates/cgp-macro-lib/src/parse/simple_type.rs
@@ -4,12 +4,15 @@ use syn::token::Lt;
 use syn::{AngleBracketedGenericArguments, Ident};
 
 #[derive(Clone)]
-pub struct SimpleType {
+pub struct SimpleType<Generics = AngleBracketedGenericArguments> {
     pub name: Ident,
-    pub generics: Option<AngleBracketedGenericArguments>,
+    pub generics: Option<Generics>,
 }
 
-impl Parse for SimpleType {
+impl<Generics> Parse for SimpleType<Generics>
+where
+    Generics: Parse,
+{
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let name: Ident = input.parse()?;
         let generics = if input.peek(Lt) {

--- a/crates/cgp-macro-lib/src/preset/impl_is_preset.rs
+++ b/crates/cgp-macro-lib/src/preset/impl_is_preset.rs
@@ -4,18 +4,18 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{parse_quote, Ident, ItemImpl, Type};
 
-use crate::parse::{DelegateComponentEntry, DelegateComponentName, ImplGenerics, SimpleType};
+use crate::parse::{DelegateEntry, DelegateKey, ImplGenerics, SimpleType};
 
 pub fn impl_components_is_preset(
     trait_name: &Ident,
     preset_type: &Type,
     preset_generics: &ImplGenerics,
-    delegate_entries: &Punctuated<DelegateComponentEntry<SimpleType>, Comma>,
+    delegate_entries: &Punctuated<DelegateEntry<SimpleType>, Comma>,
 ) -> Vec<ItemImpl> {
     delegate_entries
         .iter()
         .flat_map(|entry| {
-            entry.components.iter().map(|component| {
+            entry.keys.iter().map(|component| {
                 impl_component_is_preset(trait_name, preset_type, preset_generics, component)
             })
         })
@@ -26,11 +26,11 @@ pub fn impl_component_is_preset(
     trait_name: &Ident,
     _preset_type: &Type,
     _preset_generics: &ImplGenerics,
-    component: &DelegateComponentName<SimpleType>,
+    component: &DelegateKey<SimpleType>,
 ) -> ItemImpl {
-    let component_type = &component.component_type;
+    let component_type = &component.ty;
 
-    let mut generics = component.component_generics.generics.clone();
+    let mut generics = component.generics.generics.clone();
     generics.params.push(parse_quote!(T));
 
     let impl_generics = generics.split_for_impl().0;

--- a/crates/cgp-tests/src/tests/delegate_components/mod.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/mod.rs
@@ -1,0 +1,1 @@
+pub mod new_struct;

--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -54,13 +54,14 @@ pub fn test_delegate_components_with_new_value() {
     struct FooKey;
     struct FooValue;
     struct BarKey;
-    struct BarValue;
+    struct BazKey;
+    struct BazValue;
 
     delegate_components! {
         struct MyComponents {
             FooKey: FooValue,
             BarKey: UseDelegate<struct BarValue {
-
+                BazKey: BazValue,
             }>,
         }
     }
@@ -72,4 +73,8 @@ pub fn test_delegate_components_with_new_value() {
     }
 
     impl CheckDelegates for MyComponents {}
+
+    trait CheckInnerDelegates: DelegateComponent<BazKey, Delegate = BazValue> {}
+
+    impl CheckInnerDelegates for BarValue {}
 }

--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -1,0 +1,50 @@
+#![allow(unused)]
+
+use core::marker::PhantomData;
+
+use cgp::prelude::*;
+
+pub fn test_delegate_components_with_new_struct() {
+    struct FooKey;
+    struct FooValue;
+    struct BarKey;
+    struct BarValue;
+
+    delegate_components! {
+        struct MyComponents {
+            FooKey: FooValue,
+            BarKey: BarValue,
+        }
+    }
+
+    trait CheckDelegates:
+        DelegateComponent<FooKey, Delegate = FooValue>
+        + DelegateComponent<BarKey, Delegate = BarValue>
+    {
+    }
+
+    impl CheckDelegates for MyComponents {}
+}
+
+pub fn test_delegate_components_with_new_generic_struct() {
+    struct FooKey<T>(PhantomData<T>);
+    struct FooValue;
+    struct BarKey;
+    struct BarValue<T>(PhantomData<T>);
+
+    delegate_components! {
+        <T>
+        struct MyComponents<T> {
+            FooKey<T>: FooValue,
+            BarKey: BarValue<T>,
+        }
+    }
+
+    trait CheckDelegates<T>:
+        DelegateComponent<FooKey<T>, Delegate = FooValue>
+        + DelegateComponent<BarKey, Delegate = BarValue<T>>
+    {
+    }
+
+    impl<T> CheckDelegates<T> for MyComponents<T> {}
+}

--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -34,7 +34,6 @@ pub fn test_delegate_components_with_new_generic_struct() {
     struct BarValue<T>(PhantomData<T>);
 
     delegate_components! {
-        <T>
         new MyComponents<T> {
             FooKey<T>: FooValue,
             BarKey: BarValue<T>,
@@ -77,4 +76,33 @@ pub fn test_delegate_components_with_new_value() {
     trait CheckInnerDelegates: DelegateComponent<BazKey, Delegate = BazValue> {}
 
     impl CheckInnerDelegates for BarValue {}
+}
+
+pub fn test_delegate_components_with_generic_new_value() {
+    struct FooKey;
+    struct FooValue;
+    struct BarKey<T>(pub PhantomData<T>);
+    struct BazKey;
+    struct BazValue<T>(pub PhantomData<T>);
+
+    delegate_components! {
+        new MyComponents {
+            FooKey: FooValue,
+            <T> BarKey<T>: UseDelegate<new BarValue<T> {
+                BazKey: BazValue<T>,
+            }>,
+        }
+    }
+
+    trait CheckDelegates<T>:
+        DelegateComponent<FooKey, Delegate = FooValue>
+        + DelegateComponent<BarKey<T>, Delegate = UseDelegate<BarValue<T>>>
+    {
+    }
+
+    impl<T> CheckDelegates<T> for MyComponents {}
+
+    trait CheckInnerDelegates<T>: DelegateComponent<BazKey, Delegate = BazValue<T>> {}
+
+    impl<T> CheckInnerDelegates<T> for BarValue<T> {}
 }

--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -106,3 +106,38 @@ pub fn test_delegate_components_with_generic_new_value() {
 
     impl<T> CheckInnerDelegates<T> for BarValue<T> {}
 }
+
+pub mod test_delegate_new_value_in_preset {
+    #[cgp::re_export_imports]
+    mod preset {
+        use cgp::core::component::UseDelegate;
+        use cgp::prelude::{DelegateComponent, *};
+
+        pub struct FooKey;
+        pub struct FooValue;
+        pub struct BarKey;
+        pub struct BazKey;
+        pub struct BazValue;
+
+        cgp_preset! {
+            PresetWithNewValue {
+                FooKey: FooValue,
+                BarKey: UseDelegate<new BarValue {
+                    BazKey: BazValue,
+                }>
+            }
+        }
+
+        pub trait CheckDelegates:
+            DelegateComponent<FooKey, Delegate = FooValue>
+            + DelegateComponent<BarKey, Delegate = UseDelegate<BarValue>>
+        {
+        }
+
+        impl CheckDelegates for PresetWithNewValue::Provider {}
+
+        pub trait CheckInnerDelegates: DelegateComponent<BazKey, Delegate = BazValue> {}
+
+        impl CheckInnerDelegates for BarValue {}
+    }
+}

--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -12,7 +12,7 @@ pub fn test_delegate_components_with_new_struct() {
     struct BarValue;
 
     delegate_components! {
-        struct MyComponents {
+        new MyComponents {
             FooKey: FooValue,
             BarKey: BarValue,
         }
@@ -35,7 +35,7 @@ pub fn test_delegate_components_with_new_generic_struct() {
 
     delegate_components! {
         <T>
-        struct MyComponents<T> {
+        new MyComponents<T> {
             FooKey<T>: FooValue,
             BarKey: BarValue<T>,
         }
@@ -58,9 +58,9 @@ pub fn test_delegate_components_with_new_value() {
     struct BazValue;
 
     delegate_components! {
-        struct MyComponents {
+        new MyComponents {
             FooKey: FooValue,
-            BarKey: UseDelegate<struct BarValue {
+            BarKey: UseDelegate<new BarValue {
                 BazKey: BazValue,
             }>,
         }

--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -2,6 +2,7 @@
 
 use core::marker::PhantomData;
 
+use cgp::core::component::UseDelegate;
 use cgp::prelude::*;
 
 pub fn test_delegate_components_with_new_struct() {
@@ -47,4 +48,28 @@ pub fn test_delegate_components_with_new_generic_struct() {
     }
 
     impl<T> CheckDelegates<T> for MyComponents<T> {}
+}
+
+pub fn test_delegate_components_with_new_value() {
+    struct FooKey;
+    struct FooValue;
+    struct BarKey;
+    struct BarValue;
+
+    delegate_components! {
+        struct MyComponents {
+            FooKey: FooValue,
+            BarKey: UseDelegate<struct BarValue {
+
+            }>,
+        }
+    }
+
+    trait CheckDelegates:
+        DelegateComponent<FooKey, Delegate = FooValue>
+        + DelegateComponent<BarKey, Delegate = UseDelegate<BarValue>>
+    {
+    }
+
+    impl CheckDelegates for MyComponents {}
 }

--- a/crates/cgp-tests/src/tests/mod.rs
+++ b/crates/cgp-tests/src/tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod r#async;
 pub mod blanket_trait;
 pub mod check_components;
+pub mod delegate_components;
 pub mod getter;
 pub mod has_fields;
 pub mod preset;


### PR DESCRIPTION
## Summary

This PR enhances the `delegate_components!` and `cgp_preset!` macro to enable definition of new structs, as well as nested delegation.

## Auto define new component struct

Prior to this PR, a component struct needs to be defined externally before we can use it with `delegate_components!`. For example:

```rust
pub struct MyComponents;

delegate_components! {
    MyComponents {
        FooComponent: FooProvider,
        BarComponent, BarProvider,
    }
}
```

With this PR, we can now use a `new` keyword to auto derive an empty component struct within the macro:

```rust
delegate_components! {
    new MyComponents {
        FooComponent: FooProvider,
        BarComponent, BarProvider,
    }
}
```

## Nested Delegation

In more advanced use of CGP, especially with `UseDelegate`, it is common to define nested delegation of an entry to another sub-component that also contains `delegate_components!` mapping, such as:

```rust
delegate_components! {
    new MyComponents {
        FooGetterComponent: UseDelegate<FooGetters>,
    }
}

delegate_components! {
    new FooGetters {
        Index<0>: UseField<symbol!("foo_a")>,
        Index<1>: UseField<symbol!("foo_b")>,
    }
}
```

With this PR, we can now define nested delegation directly within one `delegate_components!` call, using the `new` keyword:

```rust
delegate_components! {
    new MyComponents {
        FooGetterComponent: UseDelegate<new FooGetters {
            Index<0>: UseField<symbol!("foo_a")>,
            Index<1>: UseField<symbol!("foo_b")>,
        }>,
    }
}
```