### PR TITLE
Simplify attribute arguments for `#[cgp_component]`, `#[cgp_provider]` and `#[cgp_context]`

### DIFF
--- a/crates/cgp-macro-lib/src/derive_provider/component_name.rs
+++ b/crates/cgp-macro-lib/src/derive_provider/component_name.rs
@@ -2,6 +2,8 @@ use quote::ToTokens;
 use syn::spanned::Spanned;
 use syn::{parse2, Error, Ident, ItemImpl, Type};
 
+use crate::parse::SimpleType;
+
 pub fn derive_component_name_from_provider_impl(provider_impl: &ItemImpl) -> syn::Result<Type> {
     let provider_trait = provider_impl.trait_.as_ref().ok_or_else(|| {
         Error::new(
@@ -10,9 +12,12 @@ pub fn derive_component_name_from_provider_impl(provider_impl: &ItemImpl) -> syn
         )
     })?;
 
-    let provider_ident: Ident = parse2(provider_trait.1.to_token_stream())?;
+    let provider_trait: SimpleType = parse2(provider_trait.1.to_token_stream())?;
 
-    let component_ident = Ident::new(&format!("{provider_ident}Component"), provider_ident.span());
+    let component_ident = Ident::new(
+        &format!("{}Component", provider_trait.name),
+        provider_trait.span(),
+    );
 
     parse2(component_ident.to_token_stream())
 }

--- a/crates/cgp-macro-lib/src/derive_provider/component_name.rs
+++ b/crates/cgp-macro-lib/src/derive_provider/component_name.rs
@@ -1,0 +1,18 @@
+use quote::ToTokens;
+use syn::spanned::Spanned;
+use syn::{parse2, Error, Ident, ItemImpl, Type};
+
+pub fn derive_component_name_from_provider_impl(provider_impl: &ItemImpl) -> syn::Result<Type> {
+    let provider_trait = provider_impl.trait_.as_ref().ok_or_else(|| {
+        Error::new(
+            provider_impl.span(),
+            "expect provider trait name to be present",
+        )
+    })?;
+
+    let provider_ident: Ident = parse2(provider_trait.1.to_token_stream())?;
+
+    let component_ident = Ident::new(&format!("{provider_ident}Component"), provider_ident.span());
+
+    parse2(component_ident.to_token_stream())
+}

--- a/crates/cgp-macro-lib/src/derive_provider/mod.rs
+++ b/crates/cgp-macro-lib/src/derive_provider/mod.rs
@@ -1,5 +1,7 @@
+mod component_name;
 mod derive;
 mod replace_constraint;
 
+pub use component_name::*;
 pub use derive::*;
 pub use replace_constraint::*;

--- a/crates/cgp-macro-lib/src/entrypoints/cgp_context.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_context.rs
@@ -1,14 +1,27 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse2, ItemImpl, ItemStruct};
+use syn::{parse2, Ident, ItemImpl, ItemStruct};
 
 use crate::derive_context::{derive_delegate_preset, derive_has_components};
 use crate::parse::ContextSpec;
 
 pub fn cgp_context(attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
-    let context_spec: ContextSpec = syn::parse2(attr)?;
-
     let context_struct: ItemStruct = syn::parse2(body)?;
+
+    let context_spec: ContextSpec = if !attr.is_empty() {
+        syn::parse2(attr)?
+    } else {
+        let provider_name = Ident::new(
+            &format!("{}Components", context_struct.ident),
+            context_struct.ident.span(),
+        );
+
+        ContextSpec {
+            provider_name,
+            provider_generics: None,
+            preset: None,
+        }
+    };
 
     let provider_name = &context_spec.provider_name;
     let provider_generics = &context_spec.provider_generics;

--- a/crates/cgp-macro-lib/src/entrypoints/cgp_new_provider.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_new_provider.rs
@@ -2,12 +2,18 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{ItemImpl, Type};
 
-use crate::derive_provider::{derive_is_provider_for, derive_provider_struct};
+use crate::derive_provider::{
+    derive_component_name_from_provider_impl, derive_is_provider_for, derive_provider_struct,
+};
 
 pub fn cgp_new_provider(attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
-    let component_name: Type = syn::parse2(attr)?;
-
     let provider_impl: ItemImpl = syn::parse2(body)?;
+
+    let component_name: Type = if !attr.is_empty() {
+        syn::parse2(attr)?
+    } else {
+        derive_component_name_from_provider_impl(&provider_impl)?
+    };
 
     let provider_struct = derive_provider_struct(&provider_impl)?;
 

--- a/crates/cgp-macro-lib/src/entrypoints/cgp_provider.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_provider.rs
@@ -1,13 +1,17 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{ItemImpl, Type};
+use syn::{parse2, ItemImpl, Type};
 
-use crate::derive_provider::derive_is_provider_for;
+use crate::derive_provider::{derive_component_name_from_provider_impl, derive_is_provider_for};
 
 pub fn cgp_provider(attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
-    let component_name: Type = syn::parse2(attr)?;
+    let provider_impl: ItemImpl = parse2(body)?;
 
-    let provider_impl: ItemImpl = syn::parse2(body)?;
+    let component_name: Type = if !attr.is_empty() {
+        syn::parse2(attr)?
+    } else {
+        derive_component_name_from_provider_impl(&provider_impl)?
+    };
 
     let is_provider_for_impl: ItemImpl = derive_is_provider_for(&component_name, &provider_impl)?;
 

--- a/crates/cgp-tests/src/tests/async/spawn.rs
+++ b/crates/cgp-tests/src/tests/async/spawn.rs
@@ -22,25 +22,19 @@ pub fn test_async_spawn() {
         type Bar: Async;
     }
 
-    #[cgp_component {
-        provider: FooFetcher,
-    }]
+    #[cgp_component(FooFetcher)]
     #[async_trait]
     pub trait CanFetchFoo: Async + HasFooType + HasAsyncErrorType {
         async fn fetch_foo(&self) -> Result<Self::Foo, Self::Error>;
     }
 
-    #[cgp_component {
-        provider: BarFetcher,
-    }]
+    #[cgp_component(BarFetcher)]
     #[async_trait]
     pub trait CanFetchBar: Async + HasBarType + HasAsyncErrorType {
         async fn fetch_bar(&self) -> Result<Self::Bar, Self::Error>;
     }
 
-    #[cgp_component {
-        provider: FooBarRunner,
-    }]
+    #[cgp_component(FooBarRunner)]
     #[async_trait]
     pub trait CanRunFooBar: Async + HasFooType + HasBarType + HasAsyncErrorType {
         async fn run_foo_bar(&self, foo: &Self::Foo, bar: &Self::Bar) -> Result<(), Self::Error>;

--- a/crates/cgp-tests/src/tests/cgp_component/constant.rs
+++ b/crates/cgp-tests/src/tests/cgp_component/constant.rs
@@ -15,7 +15,7 @@ pub fn test_component_with_const() {
         const CONSTANT: u64 = CONSTANT;
     }
 
-    #[cgp_context(MyContextComponents)]
+    #[cgp_context]
     pub struct MyContext;
 
     delegate_components! {
@@ -56,7 +56,7 @@ pub fn test_component_with_generic_const() {
         const CONSTANT: u64 = CONSTANT;
     }
 
-    #[cgp_context(MyContextComponents)]
+    #[cgp_context]
     pub struct MyContext;
 
     delegate_components! {

--- a/crates/cgp-tests/src/tests/cgp_component/constant.rs
+++ b/crates/cgp-tests/src/tests/cgp_component/constant.rs
@@ -1,9 +1,7 @@
 use cgp::prelude::*;
 
 pub fn test_component_with_const() {
-    #[cgp_component {
-        provider: ConstantGetter
-    }]
+    #[cgp_component(ConstantGetter)]
     pub trait HasConstant {
         const CONSTANT: u64;
     }
@@ -39,9 +37,7 @@ pub fn test_component_with_generic_const() {
         type Unit;
     }
 
-    #[cgp_component {
-        provider: ConstantGetter
-    }]
+    #[cgp_component(ConstantGetter)]
     pub trait HasConstant: HasUnitType {
         const CONSTANT: Self::Unit;
     }

--- a/crates/cgp-tests/src/tests/cgp_component/constant.rs
+++ b/crates/cgp-tests/src/tests/cgp_component/constant.rs
@@ -10,7 +10,7 @@ pub fn test_component_with_const() {
 
     pub struct UseConstant<const CONSTANT: u64>;
 
-    #[cgp_provider(ConstantGetterComponent)]
+    #[cgp_provider]
     impl<Context, const CONSTANT: u64> ConstantGetter<Context> for UseConstant<CONSTANT> {
         const CONSTANT: u64 = CONSTANT;
     }
@@ -48,7 +48,7 @@ pub fn test_component_with_generic_const() {
 
     pub struct UseConstant<const CONSTANT: u64>;
 
-    #[cgp_provider(ConstantGetterComponent)]
+    #[cgp_provider]
     impl<Context, const CONSTANT: u64> ConstantGetter<Context> for UseConstant<CONSTANT>
     where
         Context: HasUnitType<Unit = u64>,

--- a/crates/cgp-tests/src/tests/check_components.rs
+++ b/crates/cgp-tests/src/tests/check_components.rs
@@ -28,7 +28,7 @@ pub fn test_basic_check_components() {
         fn foo(&self, _tag: PhantomData<(I, J)>) -> &Self::Bar;
     }
 
-    #[cgp_context(ContextComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct Context {
         pub dummy: (),
@@ -103,7 +103,7 @@ pub fn test_generic_check_components() {
         fn foo(&self, _tag: PhantomData<(I, J)>) -> &Self::Bar;
     }
 
-    #[cgp_context(ContextComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct Context {
         pub dummy: (),

--- a/crates/cgp-tests/src/tests/getter/abstract_type.rs
+++ b/crates/cgp-tests/src/tests/getter/abstract_type.rs
@@ -12,7 +12,7 @@ pub fn test_abstract_type_getter() {
         fn name(&self) -> &Self::Name;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub name: String,
@@ -44,7 +44,7 @@ pub fn test_abstract_type_auto_getter() {
         fn name(&self) -> &Self::Name;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub name: String,

--- a/crates/cgp-tests/src/tests/getter/clone.rs
+++ b/crates/cgp-tests/src/tests/getter/clone.rs
@@ -12,7 +12,7 @@ pub fn test_clone_getter() {
         fn name(&self) -> Self::Name;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub name: String,
@@ -44,7 +44,7 @@ pub fn test_clone_auto_getter() {
         fn name(&self) -> Self::Name;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub name: String,

--- a/crates/cgp-tests/src/tests/getter/mref.rs
+++ b/crates/cgp-tests/src/tests/getter/mref.rs
@@ -8,7 +8,7 @@ pub fn test_mref_getter() {
         fn foo(&self) -> MRef<'_, String>;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub bar: String,

--- a/crates/cgp-tests/src/tests/getter/option.rs
+++ b/crates/cgp-tests/src/tests/getter/option.rs
@@ -7,7 +7,7 @@ pub fn test_option_getter() {
         fn foo(&self) -> Option<&String>;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub bar: Option<String>,
@@ -33,7 +33,7 @@ pub fn test_option_auto_getter() {
         fn foo(&self) -> Option<&String>;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub foo: Option<String>,

--- a/crates/cgp-tests/src/tests/getter/slice.rs
+++ b/crates/cgp-tests/src/tests/getter/slice.rs
@@ -7,7 +7,7 @@ pub fn test_slice_getter() {
         fn foo(&self) -> &[u8];
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub bar: Vec<u8>,

--- a/crates/cgp-tests/src/tests/getter/string.rs
+++ b/crates/cgp-tests/src/tests/getter/string.rs
@@ -7,7 +7,7 @@ pub fn test_string_getter() {
         fn foo(&self) -> &str;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub bar: String,
@@ -33,7 +33,7 @@ pub fn test_string_auto_getter() {
         fn foo(&self) -> &str;
     }
 
-    #[cgp_context(AppComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct App {
         pub foo: String,

--- a/crates/cgp-tests/src/tests/has_field/chain.rs
+++ b/crates/cgp-tests/src/tests/has_field/chain.rs
@@ -98,7 +98,7 @@ fn test_deeply_nested_getter() {
         pub name: String,
     }
 
-    #[cgp_context(MyContextComponents)]
+    #[cgp_context]
     #[derive(HasField)]
     pub struct MyContext {
         pub a: A,


### PR DESCRIPTION
## Summary

This PR enhances the `#[cgp_component`, `#[cgp_provider]` and `#[cgp_context]` macros, so that the attribute arguments can be simplified.

## `#[cgp_component]`

If the user only wants to specify the `provider` key, the expression can be simplified from `#[cgp_component{ provider: ProviderName }` to `#[cgp_component(ProviderName]`.

## `#[cgp_provider]`

If no attribute is provided, the component name is deduced from the provider name, in the format `"{ProviderName}Component"`

## `#[cgp_context]`

If no attribute is provided, the context provider name is deduced from the context struct name, in the format `"{ContextName}Components"`.

## Example

Prior to this, the macro requires at least the component name and the provider name to be specified, such as:

```rust
#[cgp_component {
    provider: Greeter,
}]
pub trait CanGreet {
    fn greet(&self);
}

#[cgp_new_provider(GreeterComponent)]
impl<Context> Greeter<Context> for GreetHello {
    fn greet(&self) {
        println!("Hello, World!");
    }
}

#[cgp_context(MyContextComponents)]
pub struct MyContext;

delegate_components! {
    MyContextComponents {
        GreeterComponent: GreetHello,
    }
}
```


After this PR, the names can omitted and simplified to:

```rust
#[cgp_component(Greeter)]
pub trait CanGreet {
    fn greet(&self);
}

#[cgp_new_provider]
impl<Context> Greeter<Context> for GreetHello {
    fn greet(&self) {
        println!("Hello, World!");
    }
}

#[cgp_context]
pub struct MyContext;

delegate_components! {
    MyContextComponents {
        GreeterComponent: GreetHello,
    }
}
```