### PR TITLE
Rename `HasProvider` trait to `HasCgpProvider`

### DIFF
--- a/crates/cgp-component/src/lib.rs
+++ b/crates/cgp-component/src/lib.rs
@@ -1,11 +1,11 @@
 #![no_std]
 
 /*!
-   This crate defines the core CGP traits, [`DelegateComponent`] and [`HasProvider`].
+   This crate defines the core CGP traits, [`DelegateComponent`] and [`HasCgpProvider`].
 */
 
 mod traits;
 mod types;
 
-pub use traits::{CanUseComponent, DelegateComponent, HasProvider, IsProviderFor};
+pub use traits::{CanUseComponent, DelegateComponent, HasCgpProvider, IsProviderFor};
 pub use types::{UseContext, UseDelegate, UseFields, WithContext, WithProvider};

--- a/crates/cgp-component/src/traits/can_use_component.rs
+++ b/crates/cgp-component/src/traits/can_use_component.rs
@@ -1,10 +1,10 @@
-use crate::{HasProvider, IsProviderFor};
+use crate::{HasCgpProvider, IsProviderFor};
 
 pub trait CanUseComponent<Component, Params = ()> {}
 
 impl<Context, Component, Params> CanUseComponent<Component, Params> for Context
 where
-    Context: HasProvider,
-    Context::Provider: IsProviderFor<Component, Context, Params>,
+    Context: HasCgpProvider,
+    Context::CgpProvider: IsProviderFor<Component, Context, Params>,
 {
 }

--- a/crates/cgp-component/src/traits/has_components.rs
+++ b/crates/cgp-component/src/traits/has_components.rs
@@ -1,3 +1,3 @@
-pub trait HasProvider {
-    type Provider;
+pub trait HasCgpProvider {
+    type CgpProvider;
 }

--- a/crates/cgp-component/src/traits/mod.rs
+++ b/crates/cgp-component/src/traits/mod.rs
@@ -5,5 +5,5 @@ mod is_provider;
 
 pub use can_use_component::*;
 pub use delegate_component::DelegateComponent;
-pub use has_components::HasProvider;
+pub use has_components::HasCgpProvider;
 pub use is_provider::*;

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use cgp_async::{async_trait, Async, MaybeSend, MaybeSync};
 pub use cgp_component::{
-    CanUseComponent, DelegateComponent, HasProvider, IsProviderFor, UseContext, UseFields,
+    CanUseComponent, DelegateComponent, HasCgpProvider, IsProviderFor, UseContext, UseFields,
     WithContext, WithProvider,
 };
 pub use cgp_error::{

--- a/crates/cgp-error/src/traits/can_raise_error.rs
+++ b/crates/cgp-error/src/traits/can_raise_error.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, UseDelegate};
+use cgp_component::{DelegateComponent, HasCgpProvider, IsProviderFor, UseContext, UseDelegate};
 use cgp_macro::{cgp_component, cgp_provider};
 
 use crate::traits::has_error_type::HasErrorType;

--- a/crates/cgp-error/src/traits/can_wrap_error.rs
+++ b/crates/cgp-error/src/traits/can_wrap_error.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, UseDelegate};
+use cgp_component::{DelegateComponent, HasCgpProvider, IsProviderFor, UseContext, UseDelegate};
 use cgp_macro::{cgp_component, cgp_provider};
 
 use crate::traits::HasErrorType;

--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, WithProvider};
+use cgp_component::{DelegateComponent, HasCgpProvider, IsProviderFor, UseContext, WithProvider};
 use cgp_macro::cgp_type;
 use cgp_type::{ProvideType, UseType};
 

--- a/crates/cgp-macro-lib/src/derive_component/consumer_impl.rs
+++ b/crates/cgp-macro-lib/src/derive_component/consumer_impl.rs
@@ -61,7 +61,7 @@ pub fn derive_consumer_impl(
 
         {
             let has_component_constraint: TypeParamBound = parse2(quote! {
-                HasProvider
+                HasCgpProvider
             })?;
 
             let provider_constraint: TypeParamBound = parse2(quote! {
@@ -75,14 +75,14 @@ pub fn derive_consumer_impl(
                     })?);
 
                     where_clause.predicates.push(parse2(quote! {
-                        #context_type :: Provider : #provider_constraint
+                        #context_type :: CgpProvider : #provider_constraint
                     })?);
                 }
                 _ => {
                     generics.where_clause = Some(parse2(quote! {
                         where
                             #context_type : #has_component_constraint,
-                            #context_type :: Provider : #provider_constraint
+                            #context_type :: CgpProvider : #provider_constraint
                     })?);
                 }
             }
@@ -98,7 +98,7 @@ pub fn derive_consumer_impl(
             TraitItem::Fn(trait_fn) => {
                 let impl_fn = derive_delegated_fn_impl(
                     &trait_fn.sig,
-                    &parse2(quote!(#context_type :: Provider))?,
+                    &parse2(quote!(#context_type :: CgpProvider))?,
                 )?;
 
                 impl_items.push(ImplItem::Fn(impl_fn));
@@ -121,7 +121,7 @@ pub fn derive_consumer_impl(
                 let impl_type = derive_delegate_type_impl(
                     trait_type,
                     parse2(quote!(
-                        < #context_type :: Provider as #provider_name < #provider_type_generics > > :: #type_name #type_generics
+                        < #context_type :: CgpProvider as #provider_name < #provider_type_generics > > :: #type_name #type_generics
                     ))?,
                 );
 
@@ -132,7 +132,7 @@ pub fn derive_consumer_impl(
                 let (_, type_generics, _) = trait_item_const.generics.split_for_impl();
 
                 let impl_expr = parse2(quote! {
-                    < #context_type :: Provider as #provider_name < #provider_type_generics > > :: #const_ident #type_generics
+                    < #context_type :: CgpProvider as #provider_name < #provider_type_generics > > :: #const_ident #type_generics
                 })?;
 
                 let impl_item_const = ImplItemConst {

--- a/crates/cgp-macro-lib/src/derive_context/derive.rs
+++ b/crates/cgp-macro-lib/src/derive_context/derive.rs
@@ -13,10 +13,10 @@ pub fn derive_has_components(
     let (impl_generics, ty_generics, where_clause) = context_struct.generics.split_for_impl();
 
     parse2(quote! {
-        impl #impl_generics HasProvider for #context_name #ty_generics
+        impl #impl_generics HasCgpProvider for #context_name #ty_generics
             #where_clause
         {
-            type Provider = #provider_name #provider_generics;
+            type CgpProvider = #provider_name #provider_generics;
         }
     })
 }

--- a/crates/cgp-macro-lib/src/tests/derive_component.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_component.rs
@@ -56,12 +56,12 @@ fn test_derive_component_with_const_generic() {
         impl<Context, const BAR: usize> HasFoo<BAR> for Context
         where
             Context: HasCgpProvider,
-            Context::Provider: FooProvider<Context, BAR>,
+            Context::CgpProvider: FooProvider<Context, BAR>,
         {
-            type Foo = <Context::Provider as FooProvider<Context, BAR>>::Foo;
+            type Foo = <Context::CgpProvider as FooProvider<Context, BAR>>::Foo;
 
             fn foo(&self) -> Self::Foo {
-                Context::Provider::foo(self)
+                Context::CgpProvider::foo(self)
             }
         }
 

--- a/crates/cgp-macro-lib/src/tests/derive_component.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_component.rs
@@ -55,7 +55,7 @@ fn test_derive_component_with_const_generic() {
 
         impl<Context, const BAR: usize> HasFoo<BAR> for Context
         where
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: FooProvider<Context, BAR>,
         {
             type Foo = <Context::Provider as FooProvider<Context, BAR>>::Foo;

--- a/crates/cgp-macro-lib/src/tests/derive_context.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_context.rs
@@ -33,7 +33,7 @@ fn test_basic_derive_context() {
         where
             Bar: BazConstraint,
         {
-            type Provider = FooComponents;
+            type CgpProvider = FooComponents;
         }
     };
 
@@ -71,7 +71,7 @@ fn test_derive_context_with_preset() {
         where
             Bar: BazConstraint,
         {
-            type Provider = FooComponents;
+            type CgpProvider = FooComponents;
         }
 
         impl<__Name__> DelegateComponent<__Name__> for FooComponents

--- a/crates/cgp-macro-lib/src/tests/derive_context.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_context.rs
@@ -29,7 +29,7 @@ fn test_basic_derive_context() {
 
         pub struct FooComponents;
 
-        impl<Bar: BarConstraint> HasProvider for FooContext<Bar>
+        impl<Bar: BarConstraint> HasCgpProvider for FooContext<Bar>
         where
             Bar: BazConstraint,
         {
@@ -67,7 +67,7 @@ fn test_derive_context_with_preset() {
 
         pub struct FooComponents;
 
-        impl<Bar: BarConstraint> HasProvider for FooContext<Bar>
+        impl<Bar: BarConstraint> HasCgpProvider for FooContext<Bar>
         where
             Bar: BazConstraint,
         {

--- a/crates/cgp-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_getter.rs
@@ -34,7 +34,7 @@ fn test_derive_getter_basic() {
         impl<Context> HasName for Context
         where
             Context: HasNameType,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context>,
         {
             fn name(&self) -> &Self::Name {
@@ -159,7 +159,7 @@ fn test_derive_getter_str() {
         }
         impl<Context> HasName for Context
         where
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context>,
         {
             fn name(&self) -> &str {
@@ -267,7 +267,7 @@ fn test_derive_getter_mut_str() {
         }
         impl<Context> HasName for Context
         where
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context>,
         {
             fn name(&mut self) -> &mut str {
@@ -381,7 +381,7 @@ fn test_derive_getter_clone() {
         impl<Context> HasName for Context
         where
             Context: HasNameType<Name: Clone>,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context>,
         {
             fn name(&self) -> Self::Name {
@@ -504,7 +504,7 @@ fn test_derive_getter_option_ref() {
         impl<Context> HasName for Context
         where
             Context: HasNameType,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context>,
         {
             fn name(&self) -> Option<&Self::Name> {
@@ -627,7 +627,7 @@ fn test_derive_getter_option_mut() {
         impl<Context> HasName for Context
         where
             Context: HasNameType,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context>,
         {
             fn name(&mut self) -> Option<&mut Self::Name> {
@@ -759,7 +759,7 @@ fn test_derive_getter_with_generics() {
         impl<Context, App> HasName<App> for Context
         where
             App: HasNameType,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context, App>,
         {
             fn name(&self) -> &App::Name {
@@ -894,7 +894,7 @@ fn test_derive_getter_with_component_generics() {
         impl<Context, App> HasName<App> for Context
         where
             App: HasNameType,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context, App>,
         {
             fn name(&self) -> &App::Name {
@@ -1024,7 +1024,7 @@ fn test_derive_getter_with_phantom() {
         impl<Context, App, B> HasName<App, B> for Context
         where
             App: HasNameType,
-            Context: HasProvider,
+            Context: HasCgpProvider,
             Context::Provider: NameGetter<Context, App, B>,
         {
             fn name(&self, _phantom: PhantomData<(App, B)>) -> &App::Name {

--- a/crates/cgp-macro-lib/src/tests/derive_getter.rs
+++ b/crates/cgp-macro-lib/src/tests/derive_getter.rs
@@ -35,10 +35,10 @@ fn test_derive_getter_basic() {
         where
             Context: HasNameType,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context>,
+            Context::CgpProvider: NameGetter<Context>,
         {
             fn name(&self) -> &Self::Name {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
 
@@ -160,10 +160,10 @@ fn test_derive_getter_str() {
         impl<Context> HasName for Context
         where
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context>,
+            Context::CgpProvider: NameGetter<Context>,
         {
             fn name(&self) -> &str {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
         impl<Component, Context> NameGetter<Context> for Component
@@ -268,10 +268,10 @@ fn test_derive_getter_mut_str() {
         impl<Context> HasName for Context
         where
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context>,
+            Context::CgpProvider: NameGetter<Context>,
         {
             fn name(&mut self) -> &mut str {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
         impl<Component, Context> NameGetter<Context> for Component
@@ -382,10 +382,10 @@ fn test_derive_getter_clone() {
         where
             Context: HasNameType<Name: Clone>,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context>,
+            Context::CgpProvider: NameGetter<Context>,
         {
             fn name(&self) -> Self::Name {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
         impl<Component, Context> NameGetter<Context> for Component
@@ -505,10 +505,10 @@ fn test_derive_getter_option_ref() {
         where
             Context: HasNameType,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context>,
+            Context::CgpProvider: NameGetter<Context>,
         {
             fn name(&self) -> Option<&Self::Name> {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
         impl<Component, Context> NameGetter<Context> for Component
@@ -628,10 +628,10 @@ fn test_derive_getter_option_mut() {
         where
             Context: HasNameType,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context>,
+            Context::CgpProvider: NameGetter<Context>,
         {
             fn name(&mut self) -> Option<&mut Self::Name> {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
         impl<Component, Context> NameGetter<Context> for Component
@@ -760,10 +760,10 @@ fn test_derive_getter_with_generics() {
         where
             App: HasNameType,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context, App>,
+            Context::CgpProvider: NameGetter<Context, App>,
         {
             fn name(&self) -> &App::Name {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
 
@@ -895,10 +895,10 @@ fn test_derive_getter_with_component_generics() {
         where
             App: HasNameType,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context, App>,
+            Context::CgpProvider: NameGetter<Context, App>,
         {
             fn name(&self) -> &App::Name {
-                Context::Provider::name(self)
+                Context::CgpProvider::name(self)
             }
         }
         impl<Component, Context, App> NameGetter<Context, App> for Component
@@ -1025,10 +1025,10 @@ fn test_derive_getter_with_phantom() {
         where
             App: HasNameType,
             Context: HasCgpProvider,
-            Context::Provider: NameGetter<Context, App, B>,
+            Context::CgpProvider: NameGetter<Context, App, B>,
         {
             fn name(&self, _phantom: PhantomData<(App, B)>) -> &App::Name {
-                Context::Provider::name(self, _phantom)
+                Context::CgpProvider::name(self, _phantom)
             }
         }
         impl<Component, Context, App, B> NameGetter<Context, App, B> for Component

--- a/crates/cgp-type/src/traits/has_type.rs
+++ b/crates/cgp-type/src/traits/has_type.rs
@@ -1,4 +1,4 @@
-use cgp_component::{DelegateComponent, HasProvider, IsProviderFor, UseContext, UseDelegate};
+use cgp_component::{DelegateComponent, HasCgpProvider, IsProviderFor, UseContext, UseDelegate};
 use cgp_macro::{cgp_component, cgp_provider};
 
 #[cgp_component {


### PR DESCRIPTION
## Summary

This PR renames the `HasProvider` trait to `HasCgpProvider`, with the associated type `Provider` renamed to `CgpProvider`.

## History

In v0.3.0 and earlier versions, the trait was originally defined as `HasComponents`:

```rust
pub trait HasComponents {
    type Components;
}
```

Later in #69, it was renamed to `HasProvider`:

```rust
pub trait HasProvider {
    type Provider;
}
```

Since the use of the trait has been automated by the `#[cgp_context]` macro in #66, it is less of an issue of what name this trait is called. However, calling the trait "HasProvider" brings the issue of potential name clashes, if the users want to use the term "Provider" inside the consumer trait or abstract types. This is especially problematic, given that the trait is automatically imported into scope inside the `cgp::prelude::*`.

To avoid forcing users to find alternative terms to "Provider" for their CGP components, we are going to rename the trait to `HasCgpProvider`, so that is becomes much less unlikely for name clashes to happen.

The new trait definition becomes as follows:

```rust
pub trait HasCgpProvider {
    type CgpProvider;
}
```