### PR TITLE
Derive `HasField<Index<{i}>>` for structs with unnamed fields

### DIFF
--- a/crates/cgp-tests/src/tests/has_field/index.rs
+++ b/crates/cgp-tests/src/tests/has_field/index.rs
@@ -1,0 +1,18 @@
+use cgp::prelude::*;
+
+#[derive(HasField)]
+pub struct Context(pub String, pub u64);
+
+pub trait CheckHasFieldImpls:
+    HasField<Index<0>, Value = String> + HasField<Index<1>, Value = u64>
+{
+}
+
+impl CheckHasFieldImpls for Context {}
+
+#[test]
+fn test_has_field_index() {
+    let context = Context("test".to_owned(), 1);
+    assert_eq!(context.get_field(PhantomData::<Index<0>>), &"test");
+    assert_eq!(context.get_field(PhantomData::<Index<1>>), &1);
+}

--- a/crates/cgp-tests/src/tests/has_field/mod.rs
+++ b/crates/cgp-tests/src/tests/has_field/mod.rs
@@ -1,2 +1,3 @@
 pub mod chain;
+pub mod index;
 pub mod life;


### PR DESCRIPTION
## Summary

Previously, the derivation for `HasField` was skipped when the struct contains unnamed fields. With this PR, the struct would contain `HasField` implementations with `Index<{i}>` as the tag, where `i` is the field position.