### PR TITLE
Allow only provider name to be specified inside `#[cgp_getter]`

### DIFF
--- a/crates/cgp-macro-lib/src/entrypoints/cgp_getter.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_getter.rs
@@ -1,4 +1,5 @@
 use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
@@ -13,7 +14,11 @@ use crate::derive_provider::derive_is_provider_for;
 use crate::parse::{ComponentSpec, Entries};
 
 pub fn cgp_getter(attr: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
-    let Entries { mut entries } = parse2(attr)?;
+    let mut entries = if let Ok(provider_ident) = parse2::<Ident>(attr.clone()) {
+        BTreeMap::from([("provider".to_owned(), provider_ident.to_token_stream())])
+    } else {
+        parse2::<Entries>(attr)?.entries
+    };
 
     let consumer_trait: ItemTrait = syn::parse2(body)?;
 

--- a/crates/cgp-tests/src/tests/getter/string.rs
+++ b/crates/cgp-tests/src/tests/getter/string.rs
@@ -27,6 +27,61 @@ pub fn test_string_getter() {
 }
 
 #[test]
+pub fn test_string_getter_with_custom_name() {
+    #[cgp_getter(GetString)]
+    pub trait HasFoo {
+        fn foo(&self) -> &str;
+    }
+
+    #[cgp_context]
+    #[derive(HasField)]
+    pub struct App {
+        pub bar: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            GetStringComponent: UseField<symbol!("bar")>,
+        }
+    }
+
+    let context = App {
+        bar: "abc".to_owned(),
+    };
+
+    assert_eq!(context.foo(), "abc");
+}
+
+#[test]
+pub fn test_string_getter_with_custom_spec() {
+    #[cgp_getter{
+        provider: GetString,
+        name: GetStringComp,
+    }]
+    pub trait HasFoo {
+        fn foo(&self) -> &str;
+    }
+
+    #[cgp_context]
+    #[derive(HasField)]
+    pub struct App {
+        pub bar: String,
+    }
+
+    delegate_components! {
+        AppComponents {
+            GetStringComp: UseField<symbol!("bar")>,
+        }
+    }
+
+    let context = App {
+        bar: "abc".to_owned(),
+    };
+
+    assert_eq!(context.foo(), "abc");
+}
+
+#[test]
 pub fn test_string_auto_getter() {
     #[cgp_auto_getter]
     pub trait HasFoo {


### PR DESCRIPTION
Fixes #141

# Summary

This PR improves the syntax accepted by `#[cgp_getter]` to follow the same convention as `#[cgp_component]`. That is, a custom provider name can be provided with `#[cgp_getter(ProviderName)]`, instead of the fully qualified `#[cgp_getter { provider: ProviderName }]`.

With this PR, an example such as follows can now be written:

```rust
#[cgp_getter(GetName)]
pub trait HasName {
    fn name(&self) -> &str;
}
```