### PR TITLE
Add `?Sized` bound to `DelegateComponent`'s `Name` parameter

### DIFF
--- a/crates/cgp-component/src/traits/delegate_component.rs
+++ b/crates/cgp-component/src/traits/delegate_component.rs
@@ -43,6 +43,6 @@
     message = "{Self} does not contain any DelegateComponent entry for {Name}",
     note = "You might want to implement the provider trait for {Name} on {Self}"
 )]
-pub trait DelegateComponent<Name> {
+pub trait DelegateComponent<Name: ?Sized> {
     type Delegate;
 }


### PR DESCRIPTION
By adding the `?Sized` bound, this allows `DelegateComponent` to be used to construct type-level tables with types that do not implement `Sized` as keys.