### PR TITLE
Rename `#[cgp_dispatch]` to `#[cgp_auto_dispatch]`

### DIFF
--- a/crates/cgp-extra-macro-lib/src/entrypoints/cgp_auto_dispatch.rs
+++ b/crates/cgp-extra-macro-lib/src/entrypoints/cgp_auto_dispatch.rs
@@ -12,7 +12,7 @@ use syn::{
 
 use crate::utils::to_camel_case_str;
 
-pub fn cgp_dispatch(_attr: TokenStream, mut out: TokenStream) -> syn::Result<TokenStream> {
+pub fn cgp_auto_dispatch(_attr: TokenStream, mut out: TokenStream) -> syn::Result<TokenStream> {
     let item_trait: ItemTrait = parse2(out.clone())?;
 
     let blanket_impl = derive_blanket_impl(&item_trait)?;

--- a/crates/cgp-extra-macro-lib/src/entrypoints/mod.rs
+++ b/crates/cgp-extra-macro-lib/src/entrypoints/mod.rs
@@ -1,7 +1,7 @@
+mod cgp_auto_dispatch;
 mod cgp_computer;
-mod cgp_dispatch;
 mod cgp_producer;
 
+pub use cgp_auto_dispatch::*;
 pub use cgp_computer::*;
-pub use cgp_dispatch::*;
 pub use cgp_producer::*;

--- a/crates/cgp-extra-macro/src/lib.rs
+++ b/crates/cgp-extra-macro/src/lib.rs
@@ -15,8 +15,8 @@ pub fn cgp_computer(attr: TokenStream, body: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn cgp_dispatch(attr: TokenStream, body: TokenStream) -> TokenStream {
-    cgp_extra_macro_lib::cgp_dispatch(attr.into(), body.into())
+pub fn cgp_auto_dispatch(attr: TokenStream, body: TokenStream) -> TokenStream {
+    cgp_extra_macro_lib::cgp_auto_dispatch(attr.into(), body.into())
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/crates/cgp-extra/src/prelude.rs
+++ b/crates/cgp-extra/src/prelude.rs
@@ -2,7 +2,7 @@ pub use cgp_dispatch::{
     MatchFirstWithValueHandlers, MatchFirstWithValueHandlersMut, MatchFirstWithValueHandlersRef,
     MatchWithValueHandlers, MatchWithValueHandlersMut, MatchWithValueHandlersRef,
 };
-pub use cgp_extra_macro::{cgp_computer, cgp_dispatch, cgp_producer};
+pub use cgp_extra_macro::{cgp_auto_dispatch, cgp_computer, cgp_producer};
 pub use cgp_handler::{
     AsyncComputer, AsyncComputerComponent, AsyncComputerRef, AsyncComputerRefComponent, Computer,
     ComputerComponent, ComputerRefComponent, Handler, HandlerComponent, HandlerRefComponent,

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_generics.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_generics.rs
@@ -5,7 +5,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall<T> {
     async fn call_a(&self, _a: u64, _b: &T) -> String;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_multi_args.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_multi_args.rs
@@ -3,7 +3,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall {
     async fn call(&self, _a: u64, _b: bool) -> &'static str;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_multi_args_owned_self.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_multi_args_owned_self.rs
@@ -3,7 +3,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall {
     async fn call<'a>(self, _a: &'a mut u64, _b: bool) -> &'a str;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_multi_args_ref.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_multi_args_ref.rs
@@ -3,7 +3,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall {
     async fn call<'a>(&'a mut self, _a: &'a u64, _b: bool) -> &'a str;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_self_mut_only.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_self_mut_only.rs
@@ -3,7 +3,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall {
     async fn call(&mut self) -> &'static str;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_self_only.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_self_only.rs
@@ -3,7 +3,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall {
     async fn call(self) -> &'static str;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/async_self_ref_only.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/async_self_ref_only.rs
@@ -3,7 +3,7 @@ use futures::executor::block_on;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 #[async_trait]
 pub trait CanCall {
     async fn call(&self) -> &'static str;

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/generics.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/generics.rs
@@ -4,7 +4,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall<T> {
     fn call_a(&self, _a: u64, _b: &T) -> String;
 

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/multi_args.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/multi_args.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call(&self, _a: u64, _b: bool) -> &'static str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/multi_args_owned_self.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/multi_args_owned_self.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call(self, _a: &mut u64, _b: bool) -> &str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/multi_args_ref.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/multi_args_ref.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call<'a>(&'a mut self, _a: &'a u64, _b: bool) -> &'a str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/multi_methods.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/multi_methods.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call_a(&self, _a: u64, _b: bool) -> &str;
 

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/self_mut_only.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/self_mut_only.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call(&mut self) -> &'static str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/self_only.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/self_only.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call(self) -> &'static str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/self_ref_only.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/self_ref_only.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call(&self) -> &'static str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/self_ref_return_explicit_ref.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/self_ref_return_explicit_ref.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call<'a>(&'a self) -> &'a str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/self_ref_return_implicit_ref.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/self_ref_return_implicit_ref.rs
@@ -2,7 +2,7 @@ use cgp::prelude::*;
 
 use crate::dispatcher_macro_tests::types::{Bar, Foo, FooBar};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanCall {
     fn call(&self) -> &str;
 }

--- a/crates/cgp-tests/tests/dispatcher_macro_tests/shape.rs
+++ b/crates/cgp-tests/tests/dispatcher_macro_tests/shape.rs
@@ -17,7 +17,7 @@ pub struct Rectangle {
     pub height: f64,
 }
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait HasArea {
     fn area(&self) -> f64;
 }
@@ -34,7 +34,7 @@ impl HasArea for Rectangle {
     }
 }
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait CanScale {
     fn scale(&mut self, factor: f64);
 }

--- a/crates/cgp-tests/tests/extensible_data_tests/variants/shape.rs
+++ b/crates/cgp-tests/tests/extensible_data_tests/variants/shape.rs
@@ -99,7 +99,7 @@ fn test_shape_downcast() {
     };
 }
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait HasArea {
     fn area(self) -> f64;
 }

--- a/crates/cgp-tests/tests/extensible_data_tests/variants/shape_ref.rs
+++ b/crates/cgp-tests/tests/extensible_data_tests/variants/shape_ref.rs
@@ -8,7 +8,7 @@ use cgp::prelude::*;
 
 use super::shape::{Circle, Rectangle, Shape, ShapePlus, Triangle};
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait HasAreaRef {
     fn area(&self) -> f64;
 }
@@ -48,7 +48,7 @@ fn compute_area_ref<T: HasAreaRef>(shape: &T) -> f64 {
     shape.area()
 }
 
-#[cgp_dispatch]
+#[cgp_auto_dispatch]
 pub trait ContainerRef {
     fn contains_ref(&self, x: f64, y: f64) -> bool;
 }


### PR DESCRIPTION
# Summary

This PR renames the upcoming `#[cgp_dispatch]` macro to `#[cgp_auto_dispatch]`.

This is to reserve the original name `#[cgp_dispatch]` so that it can be applied on CGP traits. On the other hand, `#[cgp_auto_dispatch]` is designed as a simplfied tool to work with regular enums, so that users don't need to adopt the full CGP to use it.

## Example

`#[cgp_auto_dispatch]` will be used for cases like:

```rust
#[cgp_auto_dispatch]
pub trait HasArea {
    fn area(&self) -> f64;
}
```

On the other hand, in the future a new `#[cgp_dispatch]` will be implemented for CGP traits like:

```rust
#[cgp_dispatch]
#[cgp_component(AreaComputer)]
pub trait CanComputeArea<Shape> {
    fn compute_area(&self, shape: &Shape) -> f64;
}
```

where the dispatching is done on `Shape` instead of `Self`.