### PR TITLE
Implement ref variants of matcher providers

### DIFF
--- a/crates/cgp-dispatch/src/providers/matchers/match_with_field_handlers.rs
+++ b/crates/cgp-dispatch/src/providers/matchers/match_with_field_handlers.rs
@@ -1,5 +1,9 @@
 use cgp_core::prelude::*;
-use cgp_handler::{PromoteRef, UseInputDelegate};
+use cgp_handler::{
+    AsyncComputerComponent, AsyncComputerRefComponent, ComputerComponent, ComputerRefComponent,
+    HandlerComponent, HandlerRefComponent, PromoteRef, TryComputerComponent,
+    TryComputerRefComponent, UseInputDelegate,
+};
 
 use crate::providers::matchers::to_field_handlers::{HasFieldHandlers, MapExtractFieldAndHandle};
 use crate::{HandleFieldValue, MatchWithHandlers, MatchWithHandlersMut, MatchWithHandlersRef};
@@ -10,14 +14,71 @@ pub type MatchWithFieldHandlers<Provider = UseContext> =
 pub type MatchWithValueHandlers<Provider = UseContext> =
     UseInputDelegate<MatchWithFieldHandlersInputs<HandleFieldValue<Provider>>>;
 
-pub type MatchWithFieldHandlersRef<Provider = UseContext> =
-    UseInputDelegate<MatchWithFieldHandlersInputsRef<PromoteRef<Provider>>>;
+pub struct MatchWithFieldHandlersRef<Provider = UseContext>(pub PhantomData<Provider>);
 
-pub type MatchWithValueHandlersRef<Provider = UseContext> =
-    UseInputDelegate<MatchWithFieldHandlersInputsRef<HandleFieldValue<Provider>>>;
+pub struct MatchWithValueHandlersRef<Provider = UseContext>(pub PhantomData<Provider>);
 
-pub type MatchWithValueHandlersMut<Provider = UseContext> =
-    UseInputDelegate<MatchWithFieldHandlersInputsMut<HandleFieldValue<Provider>>>;
+pub struct MatchWithValueHandlersMut<Provider = UseContext>(pub PhantomData<Provider>);
+
+delegate_components! {
+    <Provider>
+    MatchWithFieldHandlersRef<Provider> {
+        [
+            ComputerComponent,
+            TryComputerComponent,
+            AsyncComputerComponent,
+            HandlerComponent,
+        ]:
+            UseInputDelegate<MatchWithFieldHandlersInputsRef<Provider>>,
+        [
+            ComputerRefComponent,
+            TryComputerRefComponent,
+            AsyncComputerRefComponent,
+            HandlerRefComponent,
+        ]:
+            PromoteRef<UseInputDelegate<MatchWithFieldHandlersInputsRef<PromoteRef<Provider>>>>,
+    }
+}
+
+delegate_components! {
+    <Provider>
+    MatchWithValueHandlersRef<Provider> {
+        [
+            ComputerComponent,
+            TryComputerComponent,
+            AsyncComputerComponent,
+            HandlerComponent,
+        ]:
+            UseInputDelegate<MatchWithFieldHandlersInputsRef<HandleFieldValue<Provider>>>,
+        [
+            ComputerRefComponent,
+            TryComputerRefComponent,
+            AsyncComputerRefComponent,
+            HandlerRefComponent,
+        ]:
+            PromoteRef<UseInputDelegate<MatchWithFieldHandlersInputsRef<HandleFieldValue<PromoteRef<Provider>>>>>,
+    }
+}
+
+delegate_components! {
+    <Provider>
+    MatchWithValueHandlersMut<Provider> {
+        [
+            ComputerComponent,
+            TryComputerComponent,
+            AsyncComputerComponent,
+            HandlerComponent,
+        ]:
+            UseInputDelegate<MatchWithFieldHandlersInputsMut<HandleFieldValue<Provider>>>,
+        [
+            ComputerRefComponent,
+            TryComputerRefComponent,
+            AsyncComputerRefComponent,
+            HandlerRefComponent,
+        ]:
+            PromoteRef<UseInputDelegate<MatchWithFieldHandlersInputsMut<HandleFieldValue<PromoteRef<Provider>>>>>,
+    }
+}
 
 delegate_components! {
     <Input: HasFieldHandlers<MapExtractFieldAndHandle<Provider>>, Provider>

--- a/crates/cgp-tests/tests/extensible_data_tests/variants/basic.rs
+++ b/crates/cgp-tests/tests/extensible_data_tests/variants/basic.rs
@@ -8,7 +8,9 @@ use cgp::extra::dispatch::{
     DowncastAndHandle, ExtractFieldAndHandle, HandleFieldValue, MatchWithFieldHandlers,
     MatchWithHandlers, MatchWithValueHandlersRef,
 };
-use cgp::extra::handler::{Computer, ComputerComponent, ComputerRefComponent, PromoteAsync};
+use cgp::extra::handler::{
+    Computer, ComputerComponent, ComputerRef, ComputerRefComponent, PromoteAsync,
+};
 use cgp::prelude::*;
 use futures::executor::block_on;
 
@@ -180,6 +182,15 @@ fn test_dispatch_values_ref() {
 
     assert_eq!(
         MatchWithValueHandlersRef::<ValueToStringRef>::compute(&context, code, &FooBarBaz::Foo(1)),
+        "1"
+    );
+
+    assert_eq!(
+        MatchWithValueHandlersRef::<ValueToStringRef>::compute_ref(
+            &context,
+            code,
+            &FooBarBaz::Foo(1)
+        ),
         "1"
     );
 

--- a/crates/cgp-tests/tests/extensible_data_tests/variants/shape_ref.rs
+++ b/crates/cgp-tests/tests/extensible_data_tests/variants/shape_ref.rs
@@ -31,18 +31,6 @@ impl HasAreaRef for Triangle {
     }
 }
 
-// impl<Context> HasAreaRef for Context
-// where
-//     Context: HasExtractorRef,
-//     MatchWithValueHandlersRef<ComputeAreaRef>: ComputerRef<(), (), Context, Output = f64>,
-//     // MatchWithValueHandlersRef<ComputeAreaRef>:
-//     //     for<'a> Computer<(), (), &'a Context, Output = f64>,
-// {
-//     fn area(&self) -> f64 {
-//         MatchWithValueHandlersRef::<ComputeAreaRef>::compute_ref(&(), NoCode, self)
-//     }
-// }
-
 #[cgp_computer]
 fn compute_area_ref<T: HasAreaRef>(shape: &T) -> f64 {
     shape.area()


### PR DESCRIPTION
# Summary

This PR implements `ComputerRef`, `TryComputerRef`, `AsyncComputerRef`, and `HandlerRef` for the matchers `MatchWithFieldHandlersRef`, `MatchWithValueHandlersRef`, and `MatchWithValueHandlersMut`.

The support for the ref variants of the provider traits for the matchers were removed in https://github.com/contextgeneric/cgp/pull/139. However, we should add it back so that the examples in the [blog post](https://contextgeneric.dev/blog/extensible-datatypes-part-2/) can remain working.