### PR TITLE
Fix use of `new` in `delegate_components!` when keys array are used

### DIFF
--- a/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
+++ b/crates/cgp-tests/src/tests/delegate_components/new_struct.rs
@@ -108,6 +108,26 @@ pub fn test_delegate_components_with_generic_new_value() {
     impl<T> CheckInnerDelegates<T> for BarValue<T> {}
 }
 
+pub fn test_delegate_new_with_array_key() {
+    pub struct FooKey;
+    pub struct BarKey;
+    pub struct BazKey;
+
+    delegate_components! {
+        new MyComponents {
+            [
+                FooKey,
+                BarKey,
+                BazKey,
+            ]:
+                UseDelegate<new InnerComponents {
+                    u32: String,
+                    u64: bool,
+                }>,
+        }
+    }
+}
+
 pub mod test_delegate_new_value_in_preset {
     #[cgp::re_export_imports]
     mod preset {


### PR DESCRIPTION
## Summary

This PR fixes a bug in `delegate_components!`, when value expressions such as `UseDelegate<new InnerComponents { ... }>` are used together with multiple keys in an array.

For example, given the following:

```rust
delegate_components! {
    MyAppComponents {
        [
            FooComponent,
            BarComponent,
        ]:
            UseDelegate<new InnerComponents {
                u64: HandleNumber,
                String: HandleString,
            }>,
    }
}
```

Previously, the inner struct `InnerComponents` would be expanded twice. With this PR, the struct `InnerComponents` would be expanded once regardless of how many keys are in the delegate entry.