### PR TITLE
Add `Life` type to represent lifetimes as types

### DIFF
--- a/crates/cgp-component/src/traits/can_use_component.rs
+++ b/crates/cgp-component/src/traits/can_use_component.rs
@@ -15,7 +15,7 @@ use crate::{HasCgpProvider, IsProviderFor};
 */
 pub trait CanUseComponent<Component, Params: ?Sized = ()> {}
 
-impl<Context, Component, Params> CanUseComponent<Component, Params> for Context
+impl<Context, Component, Params: ?Sized> CanUseComponent<Component, Params> for Context
 where
     Context: HasCgpProvider,
     Context::CgpProvider: IsProviderFor<Component, Context, Params>,

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -14,7 +14,7 @@ pub use cgp_field::traits::{
     ToFieldsRef, UpdateField,
 };
 pub use cgp_field::types::{
-    Chars, Cons, Either, Field, Index, Nil, Symbol, Void, δ, ε, ζ, θ, π, σ, ψ, ω,
+    Chars, Cons, Either, Field, Index, Life, Nil, Symbol, Void, δ, ε, ζ, θ, π, σ, ψ, ω,
 };
 pub use cgp_macro::{
     BuildField, CgpData, CgpRecord, CgpVariant, ExtractField, FromVariant, HasField, HasFields,

--- a/crates/cgp-field/src/types/life.rs
+++ b/crates/cgp-field/src/types/life.rs
@@ -1,0 +1,3 @@
+use core::marker::PhantomData;
+
+pub struct Life<'a>(pub PhantomData<*mut &'a ()>);

--- a/crates/cgp-field/src/types/mod.rs
+++ b/crates/cgp-field/src/types/mod.rs
@@ -1,6 +1,7 @@
 mod chars;
 mod field;
 mod index;
+mod life;
 mod mref;
 mod product;
 mod sum;
@@ -9,6 +10,7 @@ mod symbol;
 pub use chars::*;
 pub use field::*;
 pub use index::*;
+pub use life::*;
 pub use mref::*;
 pub use product::*;
 pub use sum::*;

--- a/crates/cgp-macro-lib/src/check_components/derive.rs
+++ b/crates/cgp-macro-lib/src/check_components/derive.rs
@@ -14,7 +14,7 @@ pub fn derive_check_components(spec: &CheckComponents) -> syn::Result<(ItemTrait
     let where_clause = &spec.where_clause;
 
     let item_trait = parse2(quote! {
-        trait #trait_name <__Component__, __Params__>: CanUseComponent<__Component__, __Params__> {}
+        trait #trait_name <__Component__, __Params__: ?Sized>: CanUseComponent<__Component__, __Params__> {}
     })?;
 
     for CheckEntry {

--- a/crates/cgp-macro-lib/src/delegate_components/define_struct.rs
+++ b/crates/cgp-macro-lib/src/delegate_components/define_struct.rs
@@ -26,7 +26,7 @@ pub fn define_struct(ident: &Ident, generics: &Generics) -> syn::Result<ItemStru
                     life_param.bounds.clear();
 
                     let lifetime = &life_param.lifetime;
-                    phantom_params.push(parse2(quote!( & #lifetime () ))?);
+                    phantom_params.push(parse2(quote!( Life<#lifetime> ))?);
                 }
                 _ => {}
             }

--- a/crates/cgp-macro-lib/src/derive_provider/derive.rs
+++ b/crates/cgp-macro-lib/src/derive_provider/derive.rs
@@ -74,8 +74,8 @@ pub fn derive_is_provider_for(
             for arg in generic_args.by_ref() {
                 if let GenericArgument::Lifetime(life) = arg {
                     // Lifetime params are forced to be pushed to the front of a provider trait.
-                    // Skip those and put them in the form of `&'a ()` inside the IsProviderFor params
-                    is_provider_params.push(parse_quote! { & #life () })
+                    // Skip those and put them in the form of `Life<'a>` inside the IsProviderFor params
+                    is_provider_params.push(parse_quote! { Life<#life> })
                 } else {
                     // Find the first non-lifetime context type argument and break
                     context_arg = Some(arg);

--- a/crates/cgp-macro-lib/src/parse/is_provider_params.rs
+++ b/crates/cgp-macro-lib/src/parse/is_provider_params.rs
@@ -15,7 +15,7 @@ pub fn parse_is_provider_params(generics: &Generics) -> syn::Result<Punctuated<T
             }
             GenericParam::Lifetime(life_param) => {
                 let life = &life_param.lifetime;
-                parse_quote! { & #life () }
+                parse_quote! { Life<#life> }
             }
             GenericParam::Const(_) => {
                 unimplemented!("const generic parameters are not yet supported in CGP traits")

--- a/crates/cgp-tests/src/tests/cgp_component/lifetime.rs
+++ b/crates/cgp-tests/src/tests/cgp_component/lifetime.rs
@@ -27,9 +27,9 @@ impl<'a> ReferenceGetter<'a, App<'a>, str> for AppComponents {
     }
 }
 
-// check_components! {
-//     <'a> CanUseApp for App<'a> {
-//         ReferenceGetterComponent:
-//             (Life<'a>, str),
-//     }
-// }
+check_components! {
+    <'a> CanUseApp for App<'a> {
+        ReferenceGetterComponent:
+            (Life<'a>, str),
+    }
+}

--- a/crates/cgp-tests/src/tests/cgp_component/lifetime.rs
+++ b/crates/cgp-tests/src/tests/cgp_component/lifetime.rs
@@ -26,3 +26,10 @@ impl<'a> ReferenceGetter<'a, App<'a>, str> for AppComponents {
         app.value
     }
 }
+
+// check_components! {
+//     <'a> CanUseApp for App<'a> {
+//         ReferenceGetterComponent:
+//             (Life<'a>, str),
+//     }
+// }


### PR DESCRIPTION
# Summary

This PR introduces a new `Life` type to represent lifetimes as types, which is defined as:

```rust
pub struct Life<'a>(pub PhantomData<*mut &'a ()>);
```

`Life` uses `*mut &'a` to represent an invariant lifetime `'a` that cannot be casted to any other lifetime.

Previously, lifetimes in CGP components has `&'a ()` as their type-level representation. By using `Life`, this simplifies the use of lifetimes with other parameters in a CGP component.

## Example

Given the following component:

```rust
#[cgp_component(ReferenceGetter)]
pub trait HasReference<'a, T: 'a + ?Sized> {
    fn get_reference(&self) -> &'a T;
}
```

The lifetime parameter `'a` is used by `#[cgp_component]` inside the `IsProviderFor` parameter:

```rust
impl<'a, Component, Context, T: 'a + ?Sized> ReferenceGetter<'a, Context, T>
    for Component
where
    Component: DelegateComponent<ReferenceGetterComponent>
        + IsProviderFor<ReferenceGetterComponent, Context, (Life<'a>, T)>,
    Component::Delegate: ReferenceGetter<'a, Context, T>,
{
    fn get_reference(context: &Context) -> &'a T {
        Component::Delegate::get_reference(context)
    }
}
```

When using `check_components!`, the lifetime parameter is also used to check for the trait implementation through `CanUseComponent`:

```rust
check_components! {
    <'a> CanUseApp for App<'a> {
        ReferenceGetterComponent:
            (Life<'a>, str),
    }
}
```