### PR TITLE
Release v0.5.0-beta3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "cgp"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
  "cgp-extra",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-async-macro"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -27,11 +27,11 @@ dependencies = [
 
 [[package]]
 name = "cgp-component"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 
 [[package]]
 name = "cgp-core"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-async-macro",
  "cgp-component",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-dispatch"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
  "cgp-handler",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-error"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-component",
  "cgp-macro",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-anyhow"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "anyhow",
  "cgp-core",
@@ -69,14 +69,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-extra"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-error-eyre"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
  "eyre",
@@ -84,14 +84,14 @@ dependencies = [
 
 [[package]]
 name = "cgp-error-std"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-extra"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
  "cgp-dispatch",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-extra-macro"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-extra-macro-lib",
  "syn",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-extra-macro-lib"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-field"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-component",
  "cgp-type",
@@ -132,21 +132,21 @@ dependencies = [
 
 [[package]]
 name = "cgp-field-extra"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-field",
 ]
 
 [[package]]
 name = "cgp-handler"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-inner"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-component",
  "cgp-macro",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-macro"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-macro-lib",
  "syn",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-macro-lib"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "itertools",
  "prettyplease",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-monad"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
  "cgp-handler",
@@ -181,21 +181,21 @@ dependencies = [
 
 [[package]]
 name = "cgp-run"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-runtime"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-core",
 ]
 
 [[package]]
 name = "cgp-tests"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp",
  "const_format",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "cgp-type"
-version = "0.5.0-beta"
+version = "0.5.0-beta3"
 dependencies = [
  "cgp-component",
  "cgp-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,23 +38,23 @@ authors         = ["Soares Chen <soares.chen@maybevoid.com>"]
 keywords        = ["cgp"]
 
 [workspace.dependencies]
-cgp                         = { version = "0.5.0-beta", path = "./crates/cgp" }
-cgp-core                    = { version = "0.5.0-beta", path = "./crates/cgp-core" }
-cgp-extra                   = { version = "0.5.0-beta", path = "./crates/cgp-extra" }
-cgp-async-macro             = { version = "0.5.0-beta", path = "./crates/cgp-async-macro" }
-cgp-component               = { version = "0.5.0-beta", path = "./crates/cgp-component" }
-cgp-macro                   = { version = "0.5.0-beta", path = "./crates/cgp-macro" }
-cgp-macro-lib               = { version = "0.5.0-beta", path = "./crates/cgp-macro-lib" }
-cgp-type                    = { version = "0.5.0-beta", path = "./crates/cgp-type" }
-cgp-field                   = { version = "0.5.0-beta", path = "./crates/cgp-field" }
-cgp-field-extra             = { version = "0.5.0-beta", path = "./crates/cgp-field-extra" }
-cgp-error                   = { version = "0.5.0-beta", path = "./crates/cgp-error" }
-cgp-error-extra             = { version = "0.5.0-beta", path = "./crates/cgp-error-extra" }
-cgp-extra-macro             = { version = "0.5.0-beta", path = "./crates/cgp-extra-macro" }
-cgp-extra-macro-lib         = { version = "0.5.0-beta", path = "./crates/cgp-extra-macro-lib" }
-cgp-handler                 = { version = "0.5.0-beta", path = "./crates/cgp-handler" }
-cgp-monad                   = { version = "0.5.0-beta", path = "./crates/cgp-monad" }
-cgp-dispatch                = { version = "0.5.0-beta", path = "./crates/cgp-dispatch" }
-cgp-run                     = { version = "0.5.0-beta", path = "./crates/cgp-run" }
-cgp-runtime                 = { version = "0.5.0-beta", path = "./crates/cgp-runtime" }
-cgp-inner                   = { version = "0.5.0-beta", path = "./crates/cgp-inner" }
+cgp                         = { version = "0.5.0-beta3", path = "./crates/cgp" }
+cgp-core                    = { version = "0.5.0-beta3", path = "./crates/cgp-core" }
+cgp-extra                   = { version = "0.5.0-beta3", path = "./crates/cgp-extra" }
+cgp-async-macro             = { version = "0.5.0-beta3", path = "./crates/cgp-async-macro" }
+cgp-component               = { version = "0.5.0-beta3", path = "./crates/cgp-component" }
+cgp-macro                   = { version = "0.5.0-beta3", path = "./crates/cgp-macro" }
+cgp-macro-lib               = { version = "0.5.0-beta3", path = "./crates/cgp-macro-lib" }
+cgp-type                    = { version = "0.5.0-beta3", path = "./crates/cgp-type" }
+cgp-field                   = { version = "0.5.0-beta3", path = "./crates/cgp-field" }
+cgp-field-extra             = { version = "0.5.0-beta3", path = "./crates/cgp-field-extra" }
+cgp-error                   = { version = "0.5.0-beta3", path = "./crates/cgp-error" }
+cgp-error-extra             = { version = "0.5.0-beta3", path = "./crates/cgp-error-extra" }
+cgp-extra-macro             = { version = "0.5.0-beta3", path = "./crates/cgp-extra-macro" }
+cgp-extra-macro-lib         = { version = "0.5.0-beta3", path = "./crates/cgp-extra-macro-lib" }
+cgp-handler                 = { version = "0.5.0-beta3", path = "./crates/cgp-handler" }
+cgp-monad                   = { version = "0.5.0-beta3", path = "./crates/cgp-monad" }
+cgp-dispatch                = { version = "0.5.0-beta3", path = "./crates/cgp-dispatch" }
+cgp-run                     = { version = "0.5.0-beta3", path = "./crates/cgp-run" }
+cgp-runtime                 = { version = "0.5.0-beta3", path = "./crates/cgp-runtime" }
+cgp-inner                   = { version = "0.5.0-beta3", path = "./crates/cgp-inner" }

--- a/crates/cgp-async-macro/Cargo.toml
+++ b/crates/cgp-async-macro/Cargo.toml
@@ -5,7 +5,7 @@ license      = { workspace = true }
 repository   = { workspace = true }
 authors      = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 keywords     = { workspace = true }
 description  = """
     Context-generic programming async macros

--- a/crates/cgp-component/Cargo.toml
+++ b/crates/cgp-component/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-component"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-core"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-dispatch/Cargo.toml
+++ b/crates/cgp-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-dispatch"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-error-anyhow/Cargo.toml
+++ b/crates/cgp-error-anyhow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-anyhow"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-error-extra/Cargo.toml
+++ b/crates/cgp-error-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-extra"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-eyre"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error-std"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-error"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-extra-macro-lib/Cargo.toml
+++ b/crates/cgp-extra-macro-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-extra-macro-lib"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-extra-macro/Cargo.toml
+++ b/crates/cgp-extra-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-extra-macro"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-extra/Cargo.toml
+++ b/crates/cgp-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-extra"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-field-extra/Cargo.toml
+++ b/crates/cgp-field-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field-extra"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-field/Cargo.toml
+++ b/crates/cgp-field/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-field"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-handler/Cargo.toml
+++ b/crates/cgp-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-handler"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-inner"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-macro-lib/Cargo.toml
+++ b/crates/cgp-macro-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-macro-lib"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-macro/Cargo.toml
+++ b/crates/cgp-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-macro"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-monad/Cargo.toml
+++ b/crates/cgp-monad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-monad"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-run"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-runtime/Cargo.toml
+++ b/crates/cgp-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-runtime"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-tests/Cargo.toml
+++ b/crates/cgp-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-tests"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp-type/Cargo.toml
+++ b/crates/cgp-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp-type"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }

--- a/crates/cgp/Cargo.toml
+++ b/crates/cgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cgp"
-version      = "0.5.0-beta2"
+version      = "0.5.0-beta3"
 edition      = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }


### PR DESCRIPTION
There was a mistake in v0.5.0-beta2 where the dependencies are linked to v0.5.0-beta, not the latest v0.5.0-beta2.