### PR TITLE
Fix duplicate generic paramters in `#[cgp_auto_getter]`

### DIFF
--- a/crates/cgp-tests/src/tests/getter/auto_generics.rs
+++ b/crates/cgp-tests/src/tests/getter/auto_generics.rs
@@ -1,0 +1,18 @@
+use cgp::prelude::*;
+
+#[cgp_auto_getter]
+pub trait HasFoo<Foo> {
+    fn foo(&self, _tag: PhantomData<Foo>) -> &Foo;
+}
+
+#[derive(HasField)]
+pub struct App {
+    pub foo: u32,
+}
+
+#[test]
+fn test_generic_auto_getter() {
+    let app = App { foo: 42 };
+
+    assert_eq!(app.foo(PhantomData::<u32>), &42);
+}

--- a/crates/cgp-tests/src/tests/getter/mod.rs
+++ b/crates/cgp-tests/src/tests/getter/mod.rs
@@ -1,4 +1,5 @@
 pub mod abstract_type;
+pub mod auto_generics;
 pub mod clone;
 pub mod mref;
 pub mod non_self;


### PR DESCRIPTION
This PR fixes the accidental generic parameter duplication introduced in #169.