### PR TITLE
Remove lowercase `symbol!` macro

### DIFF
--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -18,8 +18,8 @@ pub use cgp_field::types::{
 };
 pub use cgp_macro::{
     BuildField, CgpData, CgpRecord, CgpVariant, ExtractField, FromVariant, HasField, HasFields,
-    Product, Sum, Symbol, Symbol as symbol, cgp_auto_getter, cgp_component, cgp_context,
-    cgp_getter, cgp_new_provider, cgp_preset, cgp_provider, cgp_type, check_components,
+    Product, Sum, Symbol, cgp_auto_getter, cgp_component, cgp_context, cgp_getter,
+    cgp_new_provider, cgp_preset, cgp_provider, cgp_type, check_components,
     delegate_and_check_components, delegate_components, product, re_export_imports, replace_with,
 };
 pub use cgp_type::{HasType, ProvideType, UseType};


### PR DESCRIPTION
# Summary

This PR removes the lowercase `symbol!` macro, and requires the use of `Symbol!` from v0.5.0 onward.

The main goal is to avoid the confusion between using `Symbol!` and `symbol!`, and make it consistent that types always have the first letter capitalized.