### PR TITLE
Rename `ProvideType` to `TypeProvider`

### DIFF
--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -22,4 +22,4 @@ pub use cgp_macro::{
     cgp_inherit, cgp_new_provider, cgp_preset, cgp_provider, cgp_type, check_components,
     delegate_and_check_components, delegate_components, product, re_export_imports, replace_with,
 };
-pub use cgp_type::{HasType, ProvideType, UseType};
+pub use cgp_type::{HasType, TypeProvider, UseType};

--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use cgp_component::{DelegateComponent, IsProviderFor, UseContext, WithProvider};
 use cgp_macro::cgp_type;
-use cgp_type::{ProvideType, UseType};
+use cgp_type::{TypeProvider, UseType};
 
 /**
     The `HasErrorType` trait provides an abstract error type that can be used by

--- a/crates/cgp-field/src/impls/use_field.rs
+++ b/crates/cgp-field/src/impls/use_field.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use cgp_component::{IsProviderFor, WithProvider};
-use cgp_type::{ProvideType, TypeComponent};
+use cgp_type::{TypeProvider, TypeProviderComponent};
 
 use crate::traits::{FieldGetter, HasField, HasFieldMut, MutFieldGetter};
 
@@ -59,14 +59,14 @@ pub struct UseField<Tag>(pub PhantomData<Tag>);
 
 pub type WithField<Tag> = WithProvider<UseField<Tag>>;
 
-impl<Context, TypeTag, FieldTag, Field> ProvideType<Context, TypeTag> for UseField<FieldTag>
+impl<Context, TypeTag, FieldTag, Field> TypeProvider<Context, TypeTag> for UseField<FieldTag>
 where
     Context: HasField<FieldTag, Value = Field>,
 {
     type Type = Field;
 }
 
-impl<Context, TypeTag, FieldTag, Field> IsProviderFor<TypeComponent, Context, TypeTag>
+impl<Context, TypeTag, FieldTag, Field> IsProviderFor<TypeProviderComponent, Context, TypeTag>
     for UseField<FieldTag>
 where
     Context: HasField<FieldTag, Value = Field>,

--- a/crates/cgp-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-macro-lib/src/type_component/derive.rs
@@ -107,7 +107,7 @@ pub fn derive_type_providers(
             #provider_trait_name #type_generics
             for WithProvider< __Provider__ >
         where
-            __Provider__: ProvideType< #context_name, #component_name, Type = #type_name >,
+            __Provider__: TypeProvider< #context_name, #component_name, Type = #type_name >,
             #type_name: #type_bounds,
             #predicates
         {

--- a/crates/cgp-type/src/impls/use_delegated_type.rs
+++ b/crates/cgp-type/src/impls/use_delegated_type.rs
@@ -3,15 +3,15 @@ use core::marker::PhantomData;
 use cgp_component::{DelegateComponent, IsProviderFor, WithProvider};
 use cgp_macro::cgp_provider;
 
-use crate::TypeComponent;
-use crate::traits::ProvideType;
+use crate::TypeProviderComponent;
+use crate::traits::TypeProvider;
 
 pub struct UseDelegatedType<Components>(pub PhantomData<Components>);
 
 pub type WithDelegatedType<Components> = WithProvider<UseDelegatedType<Components>>;
 
-#[cgp_provider(TypeComponent)]
-impl<Context, Tag, Components, Type> ProvideType<Context, Tag> for UseDelegatedType<Components>
+#[cgp_provider(TypeProviderComponent)]
+impl<Context, Tag, Components, Type> TypeProvider<Context, Tag> for UseDelegatedType<Components>
 where
     Components: DelegateComponent<Tag, Delegate = Type>,
 {

--- a/crates/cgp-type/src/impls/use_type.rs
+++ b/crates/cgp-type/src/impls/use_type.rs
@@ -3,8 +3,8 @@ use core::marker::PhantomData;
 use cgp_component::{IsProviderFor, WithProvider};
 use cgp_macro::cgp_provider;
 
-use crate::TypeComponent;
-use crate::traits::ProvideType;
+use crate::TypeProviderComponent;
+use crate::traits::TypeProvider;
 
 /**
     The `UseType` pattern is used to implement a CGP abstract type with the
@@ -38,7 +38,7 @@ pub struct UseType<Type>(pub PhantomData<Type>);
 
 pub type WithType<Type> = WithProvider<UseType<Type>>;
 
-#[cgp_provider(TypeComponent)]
-impl<Context, Tag, Type> ProvideType<Context, Tag> for UseType<Type> {
+#[cgp_provider(TypeProviderComponent)]
+impl<Context, Tag, Type> TypeProvider<Context, Tag> for UseType<Type> {
     type Type = Type;
 }

--- a/crates/cgp-type/src/lib.rs
+++ b/crates/cgp-type/src/lib.rs
@@ -4,4 +4,4 @@ mod impls;
 mod traits;
 
 pub use impls::{UseDelegatedType, UseType, WithDelegatedType, WithType};
-pub use traits::{HasType, ProvideType, TypeComponent, TypeOf};
+pub use traits::{HasType, TypeOf, TypeProvider, TypeProviderComponent};

--- a/crates/cgp-type/src/traits/has_type.rs
+++ b/crates/cgp-type/src/traits/has_type.rs
@@ -2,8 +2,7 @@ use cgp_component::{DelegateComponent, IsProviderFor, UseContext, UseDelegate};
 use cgp_macro::cgp_component;
 
 #[cgp_component {
-    name: TypeComponent,
-    provider: ProvideType,
+    provider: TypeProvider,
     derive_delegate: UseDelegate<Tag>,
 }]
 pub trait HasType<Tag> {

--- a/crates/cgp-type/src/traits/mod.rs
+++ b/crates/cgp-type/src/traits/mod.rs
@@ -1,3 +1,3 @@
 mod has_type;
 
-pub use has_type::{HasType, ProvideType, TypeComponent, TypeOf};
+pub use has_type::{HasType, TypeOf, TypeProvider, TypeProviderComponent};


### PR DESCRIPTION

The `HasType` CGP trait is used internally by `#[cgp_type]` to generate helper type providers. Its provider trait was previously named `ProvideType` with a component named `TypeComponent`:

```rust
#[cgp_component {
    name: TypeComponent,
    provider: ProvideType,
    derive_delegate: UseDelegate<Tag>,
}]
pub trait HasType<Tag> {
    type Type;
}
```

v0.7.0 renames the provider to `TypeProvider` and the component to `TypeProviderComponent`:

```rust
#[cgp_component {
    provider: TypeProvider,
    derive_delegate: UseDelegate<Tag>,
}]
pub trait HasType<Tag> {
    type Type;
}
```

This brings the naming in line with the convention established by `#[cgp_type]`. For example, given:

```rust
#[cgp_type]
pub trait HasScalarType {
    type Scalar;
}
```

The generated provider name is `ScalarTypeProvider` and the component name is `ScalarTypeProviderComponent`.
