### PR TITLE
Remove `{Type}Of` type alias from `#[cgp_type]`

### DIFF
--- a/crates/cgp-error/src/traits/has_error_type.rs
+++ b/crates/cgp-error/src/traits/has_error_type.rs
@@ -27,3 +27,5 @@ use cgp_type::{TypeProvider, UseType};
 pub trait HasErrorType {
     type Error: Debug;
 }
+
+pub type ErrorOf<Context> = <Context as HasErrorType>::Error;

--- a/crates/cgp-macro-lib/src/entrypoints/cgp_type.rs
+++ b/crates/cgp-macro-lib/src/entrypoints/cgp_type.rs
@@ -2,14 +2,12 @@ use alloc::format;
 use std::collections::BTreeMap;
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote};
+use quote::{ToTokens, quote};
 use syn::{Ident, ItemTrait, parse_quote, parse2};
 
 use crate::derive_component::derive_component_with_ast;
 use crate::parse::{ComponentSpec, Entries};
-use crate::type_component::{
-    derive_type_alias, derive_type_providers, extract_item_type_from_trait,
-};
+use crate::type_component::{derive_type_providers, extract_item_type_from_trait};
 
 pub fn cgp_type(attrs: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
     let mut entries = if let Ok(provider_ident) = parse2::<Ident>(attrs.clone()) {
@@ -34,17 +32,13 @@ pub fn cgp_type(attrs: TokenStream, body: TokenStream) -> syn::Result<TokenStrea
 
     let component = derive_component_with_ast(&spec, consumer_trait)?;
 
-    let alias_type = derive_type_alias(&component.consumer_trait, &spec.context_type, &item_type)?;
-
     let type_provider_impls = derive_type_providers(&spec, &component.provider_trait, &item_type)?;
 
-    let mut out = quote! {
+    let out = quote! {
         #component
 
-        #alias_type
+        #(#type_provider_impls)*
     };
-
-    out.append_all(type_provider_impls);
 
     Ok(out)
 }

--- a/crates/cgp-macro-lib/src/type_component/derive.rs
+++ b/crates/cgp-macro-lib/src/type_component/derive.rs
@@ -1,11 +1,8 @@
-use alloc::format;
 use alloc::vec::Vec;
 
 use quote::{ToTokens, quote};
 use syn::spanned::Spanned;
-use syn::{
-    Error, Generics, Ident, ItemImpl, ItemTrait, ItemType, TraitItem, TraitItemType, Type, parse2,
-};
+use syn::{Error, Generics, ItemImpl, ItemTrait, TraitItem, TraitItemType, Type, parse2};
 
 use crate::derive_provider::derive_is_provider_for;
 use crate::parse::ComponentSpec;
@@ -35,30 +32,6 @@ pub fn extract_item_type_from_trait(consumer_trait: &ItemTrait) -> syn::Result<&
             "type trait should contain exactly one associated type item",
         )),
     }
-}
-
-pub fn derive_type_alias(
-    consumer_trait: &ItemTrait,
-    context_name: &Ident,
-    item_type: &TraitItemType,
-) -> syn::Result<ItemType> {
-    let consumer_trait_name = &consumer_trait.ident;
-
-    let (_, type_generics, _) = consumer_trait.generics.split_for_impl();
-
-    let type_generics: Generics = parse2(type_generics.to_token_stream())?;
-
-    let type_generics_params = &type_generics.params;
-
-    let type_name = &item_type.ident;
-    let alias_name = Ident::new(&format!("{type_name}Of"), type_name.span());
-
-    let alias_type: ItemType = parse2(quote! {
-        pub type #alias_name < #context_name, #type_generics_params > =
-            < #context_name as #consumer_trait_name #type_generics > :: #type_name ;
-    })?;
-
-    Ok(alias_type)
 }
 
 pub fn derive_type_providers(

--- a/crates/cgp-runtime/src/traits/has_runtime_type.rs
+++ b/crates/cgp-runtime/src/traits/has_runtime_type.rs
@@ -4,3 +4,5 @@ use cgp_core::prelude::*;
 pub trait HasRuntimeType {
     type Runtime;
 }
+
+pub type RuntimeOf<Context> = <Context as HasRuntimeType>::Runtime;


### PR DESCRIPTION

The `#[cgp_type]` macro no longer generates a type alias in the `{Type}Of` form. For example, given:

```rust
#[cgp_type]
pub trait HasScalarType {
    type Scalar;
}
```

The macro would previously generate:

```rust
pub type ScalarOf<Context> = <Context as HasScalarType>::Scalar;
```

This alias was originally provided to assist with abstract types in nested contexts. The new `#[use_type]` attribute offers significantly better ergonomics for those same use cases, so the aliases are no longer expected to be used.
