### PR TITLE
Change the default check trait name in `check_components!`

### DIFF
--- a/crates/cgp-macro-lib/src/parse/check_components.rs
+++ b/crates/cgp-macro-lib/src/parse/check_components.rs
@@ -98,7 +98,7 @@ impl Parse for CheckComponents {
             let context_type: SimpleType = parse2(context_type.to_token_stream())?;
 
             Ident::new(
-                &format!("__CanUse{}", context_type.name),
+                &format!("__Check{}", context_type.name),
                 context_type.span(),
             )
         };

--- a/crates/cgp-tests/tests/component_tests/cgp_impl/implicit_args/generics.rs
+++ b/crates/cgp-tests/tests/component_tests/cgp_impl/implicit_args/generics.rs
@@ -23,15 +23,10 @@ pub struct Rectangle {
     pub height: f64,
 }
 
-delegate_components! {
+delegate_and_check_components! {
     Rectangle {
+        #[check_params(f64)]
         AreaCalculatorComponent:
             RectangleArea,
-    }
-}
-
-check_components! {
-    Rectangle {
-        AreaCalculatorComponent: f64,
     }
 }

--- a/crates/cgp-tests/tests/component_tests/cgp_impl/shape.rs
+++ b/crates/cgp-tests/tests/component_tests/cgp_impl/shape.rs
@@ -100,7 +100,7 @@ pub struct PlainRectangle {
     pub height: f64,
 }
 
-delegate_components! {
+delegate_and_check_components! {
     PlainRectangle {
         AreaCalculatorComponent:
             RectangleAreaCalculator,
@@ -114,7 +114,7 @@ pub struct ScaledRectangle {
     pub height: f64,
 }
 
-delegate_components! {
+delegate_and_check_components! {
     ScaledRectangle {
         AreaCalculatorComponent:
             ScaledAreaCalculator<RectangleAreaCalculator>,
@@ -126,7 +126,7 @@ pub struct PlainCircle {
     pub radius: f64,
 }
 
-delegate_components! {
+delegate_and_check_components! {
     PlainCircle {
         AreaCalculatorComponent:
             CircleAreaCalculator,
@@ -139,10 +139,21 @@ pub struct ScaledCircle {
     pub radius: f64,
 }
 
-delegate_components! {
+delegate_and_check_components! {
     ScaledCircle {
         AreaCalculatorComponent:
             ScaledAreaCalculator<CircleAreaCalculator>,
+    }
+}
+
+check_components! {
+    #[check_trait(CheckScaledRectangleProviders)]
+    #[check_providers(
+        RectangleAreaCalculator,
+        ScaledAreaCalculator<RectangleAreaCalculator>,
+    )]
+    ScaledRectangle {
+        AreaCalculatorComponent,
     }
 }
 


### PR DESCRIPTION
The default check trait name in `check_components!` is changed to `__Check{Context}`. This avoids name collision if `delegate_and_check_components!` is also used in the same module, generating a different default check trait name of `__CanUse{Context}`.