### PR TITLE
Namespace macro refactoring

### DIFF
--- a/crates/core/cgp-component/src/lib.rs
+++ b/crates/core/cgp-component/src/lib.rs
@@ -11,8 +11,6 @@ mod namespaces;
 mod providers;
 mod traits;
 
-pub use namespaces::{DefaultImpls1, DefaultImpls2, DefaultNamespace};
-pub use providers::{
-    RedirectLookup, UseContext, UseDefault, UseDelegate, UseFields, WithContext, WithProvider,
-};
-pub use traits::{CanUseComponent, DelegateComponent, IsProviderFor};
+pub use namespaces::*;
+pub use providers::*;
+pub use traits::*;

--- a/crates/core/cgp-component/src/providers/use_delegate.rs
+++ b/crates/core/cgp-component/src/providers/use_delegate.rs
@@ -31,10 +31,8 @@ use core::marker::PhantomData;
     Given the following component definition:
 
     ```rust,ignore
-    #[cgp_component {
-        provider: ErrorRaiser,
-        derive_delegate: UseDelegate<SourceError>,
-    }]
+    #[cgp_component(ErrorRaiser)]
+    #[derive_delegate(UseDelegate<SourceError>)]
     pub trait CanRaiseError<SourceError>: HasErrorType {
         fn raise_error(error: SourceError) -> Self::Error;
     }

--- a/crates/core/cgp-component/src/providers/use_delegate.rs
+++ b/crates/core/cgp-component/src/providers/use_delegate.rs
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
     that overlaps on the generic parameters.
 
     The implementation of `UseDelegate` can be automatically generated through
-    the `derive_delegate` entry in `#[cgp_component]`. It is also possible to
+    the `#[derive_delegate]` attribute in `#[cgp_component]`. It is also possible to
     implement the dispatcher pattern on types other than `UseDelegate`, especially
     when there are multiple generic parameters that could be dispatched differently.
     We mainly use `UseDelegate` as the default dispatcher, so that users don't need

--- a/crates/core/cgp-component/src/traits/delegate_component.rs
+++ b/crates/core/cgp-component/src/traits/delegate_component.rs
@@ -40,9 +40,9 @@
    ```
 */
 #[diagnostic::on_unimplemented(
-    message = "{Self} does not contain any DelegateComponent entry for {Name}",
-    note = "You might want to implement the provider trait for {Name} on {Self}"
+    message = "{Self} does not contain any DelegateComponent entry for {Key}",
+    note = "You might want to implement the provider trait for {Key} on {Self}"
 )]
-pub trait DelegateComponent<Name: ?Sized> {
+pub trait DelegateComponent<Key: ?Sized> {
     type Delegate;
 }

--- a/crates/core/cgp-component/src/traits/is_delegate_key_in.rs
+++ b/crates/core/cgp-component/src/traits/is_delegate_key_in.rs
@@ -1,5 +1,0 @@
-use crate::DelegateComponent;
-
-pub trait IsDelegateKeyIn<Table> {}
-
-impl<Table, Key> IsDelegateKeyIn<Table> for Key where Table: DelegateComponent<Key> {}

--- a/crates/core/cgp-component/src/traits/is_delegate_key_in.rs
+++ b/crates/core/cgp-component/src/traits/is_delegate_key_in.rs
@@ -1,0 +1,5 @@
+use crate::DelegateComponent;
+
+pub trait IsDelegateKeyIn<Table> {}
+
+impl<Table, Key> IsDelegateKeyIn<Table> for Key where Table: DelegateComponent<Key> {}

--- a/crates/core/cgp-component/src/traits/mod.rs
+++ b/crates/core/cgp-component/src/traits/mod.rs
@@ -1,7 +1,9 @@
 mod can_use_component;
 mod delegate_component;
+mod is_delegate_key_in;
 mod is_provider;
 
 pub use can_use_component::*;
 pub use delegate_component::DelegateComponent;
+pub use is_delegate_key_in::*;
 pub use is_provider::*;

--- a/crates/core/cgp-component/src/traits/mod.rs
+++ b/crates/core/cgp-component/src/traits/mod.rs
@@ -1,9 +1,7 @@
 mod can_use_component;
 mod delegate_component;
-mod is_delegate_key_in;
 mod is_provider;
 
 pub use can_use_component::*;
 pub use delegate_component::DelegateComponent;
-pub use is_delegate_key_in::*;
 pub use is_provider::*;

--- a/crates/core/cgp-error/src/traits/can_raise_error.rs
+++ b/crates/core/cgp-error/src/traits/can_raise_error.rs
@@ -7,11 +7,9 @@ use crate::traits::has_error_type::HasErrorType;
    The `CanRaiseError` trait is used to raise any concrete error type into
    an abstract error provided by [`HasErrorType`].
 */
-#[cgp_component {
-    provider: ErrorRaiser,
-    derive_delegate: UseDelegate<SourceError>,
-}]
+#[cgp_component(ErrorRaiser)]
 #[prefix(@cgp.core.error in DefaultNamespace)]
+#[derive_delegate(UseDelegate<SourceError>)]
 pub trait CanRaiseError<SourceError>: HasErrorType {
     fn raise_error(error: SourceError) -> Self::Error;
 }

--- a/crates/core/cgp-error/src/traits/can_wrap_error.rs
+++ b/crates/core/cgp-error/src/traits/can_wrap_error.rs
@@ -3,11 +3,9 @@ use cgp_macro::cgp_component;
 
 use crate::traits::HasErrorType;
 
-#[cgp_component {
-    provider: ErrorWrapper,
-    derive_delegate: UseDelegate<Detail>,
-}]
+#[cgp_component(ErrorWrapper)]
 #[prefix(@cgp.core.error in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Detail>)]
 pub trait CanWrapError<Detail>: HasErrorType {
     fn wrap_error(error: Self::Error, detail: Detail) -> Self::Error;
 }

--- a/crates/core/cgp-type/src/traits/has_type.rs
+++ b/crates/core/cgp-type/src/traits/has_type.rs
@@ -1,10 +1,8 @@
 use cgp::macro_prelude::*;
 use cgp_macro::cgp_component;
 
-#[cgp_component {
-    provider: TypeProvider,
-    derive_delegate: UseDelegate<Tag>,
-}]
+#[cgp_component(TypeProvider)]
+#[derive_delegate(UseDelegate<Tag>)]
 pub trait HasType<Tag> {
     type Type;
 }

--- a/crates/extra/cgp-handler/src/components/async_computer.rs
+++ b/crates/extra/cgp-handler/src/components/async_computer.rs
@@ -13,6 +13,7 @@ use crate::UseInputDelegate;
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanComputeAsync<Code, Input> {
     type Output;
 
@@ -27,6 +28,7 @@ pub trait CanComputeAsync<Code, Input> {
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanComputeAsyncRef<Code, Input> {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/async_computer.rs
+++ b/crates/extra/cgp-handler/src/components/async_computer.rs
@@ -6,14 +6,10 @@ use cgp::prelude::*;
 use crate::UseInputDelegate;
 
 #[async_trait]
-#[cgp_component {
-    provider: AsyncComputer,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(AsyncComputer)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanComputeAsync<Code, Input> {
     type Output;
 
@@ -21,14 +17,10 @@ pub trait CanComputeAsync<Code, Input> {
 }
 
 #[async_trait]
-#[cgp_component {
-    provider: AsyncComputerRef,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(AsyncComputerRef)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanComputeAsyncRef<Code, Input> {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/computer.rs
+++ b/crates/extra/cgp-handler/src/components/computer.rs
@@ -12,6 +12,7 @@ use crate::UseInputDelegate;
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanCompute<Code, Input> {
     type Output;
 
@@ -25,6 +26,7 @@ pub trait CanCompute<Code, Input> {
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanComputeRef<Code, Input> {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/computer.rs
+++ b/crates/extra/cgp-handler/src/components/computer.rs
@@ -5,28 +5,20 @@ use cgp::prelude::*;
 
 use crate::UseInputDelegate;
 
-#[cgp_component {
-    provider: Computer,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(Computer)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanCompute<Code, Input> {
     type Output;
 
     fn compute(&self, _code: PhantomData<Code>, input: Input) -> Self::Output;
 }
 
-#[cgp_component {
-    provider: ComputerRef,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(ComputerRef)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanComputeRef<Code, Input> {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/handler.rs
+++ b/crates/extra/cgp-handler/src/components/handler.rs
@@ -13,6 +13,7 @@ use crate::UseInputDelegate;
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanHandle<Code, Input>: HasErrorType {
     type Output;
 
@@ -31,6 +32,7 @@ pub trait CanHandle<Code, Input>: HasErrorType {
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanHandleRef<Code, Input>: HasErrorType {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/handler.rs
+++ b/crates/extra/cgp-handler/src/components/handler.rs
@@ -6,14 +6,10 @@ use cgp::prelude::*;
 use crate::UseInputDelegate;
 
 #[async_trait]
-#[cgp_component {
-    provider: Handler,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(Handler)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanHandle<Code, Input>: HasErrorType {
     type Output;
 
@@ -25,14 +21,10 @@ pub trait CanHandle<Code, Input>: HasErrorType {
 }
 
 #[async_trait]
-#[cgp_component {
-    provider: HandlerRef,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(HandlerRef)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanHandleRef<Code, Input>: HasErrorType {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/produce.rs
+++ b/crates/extra/cgp-handler/src/components/produce.rs
@@ -7,6 +7,7 @@ use cgp::prelude::*;
     provider: Producer,
     derive_delegate: UseDelegate<Code>,
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanProduce<Code> {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/produce.rs
+++ b/crates/extra/cgp-handler/src/components/produce.rs
@@ -3,11 +3,9 @@ use core::marker::PhantomData;
 use cgp::component::UseDelegate;
 use cgp::prelude::*;
 
-#[cgp_component {
-    provider: Producer,
-    derive_delegate: UseDelegate<Code>,
-}]
+#[cgp_component(Producer)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
 pub trait CanProduce<Code> {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/try_compute.rs
+++ b/crates/extra/cgp-handler/src/components/try_compute.rs
@@ -5,14 +5,10 @@ use cgp::prelude::*;
 
 use crate::UseInputDelegate;
 
-#[cgp_component {
-    provider: TryComputer,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(TryComputer)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanTryCompute<Code, Input>: HasErrorType {
     type Output;
 
@@ -23,14 +19,10 @@ pub trait CanTryCompute<Code, Input>: HasErrorType {
     ) -> Result<Self::Output, Self::Error>;
 }
 
-#[cgp_component {
-    provider: TryComputerRef,
-    derive_delegate: [
-        UseDelegate<Code>,
-        UseInputDelegate<Input>,
-    ],
-}]
+#[cgp_component(TryComputerRef)]
 #[prefix(@cgp.extra.handler in DefaultNamespace)]
+#[derive_delegate(UseDelegate<Code>)]
+#[derive_delegate(UseInputDelegate<Input>)]
 pub trait CanTryComputeRef<Code, Input>: HasErrorType {
     type Output;
 

--- a/crates/extra/cgp-handler/src/components/try_compute.rs
+++ b/crates/extra/cgp-handler/src/components/try_compute.rs
@@ -12,6 +12,7 @@ use crate::UseInputDelegate;
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanTryCompute<Code, Input>: HasErrorType {
     type Output;
 
@@ -29,6 +30,7 @@ pub trait CanTryCompute<Code, Input>: HasErrorType {
         UseInputDelegate<Input>,
     ],
 }]
+#[prefix(@cgp.extra.handler in DefaultNamespace)]
 pub trait CanTryComputeRef<Code, Input>: HasErrorType {
     type Output;
 

--- a/crates/extra/cgp-run/src/lib.rs
+++ b/crates/extra/cgp-run/src/lib.rs
@@ -5,20 +5,16 @@ use core::marker::PhantomData;
 
 use cgp::prelude::*;
 
-#[cgp_component {
-    provider: Runner,
-    derive_delegate: UseDelegate<Code>,
-}]
+#[cgp_component(Runner)]
 #[async_trait]
+#[derive_delegate(UseDelegate<Code>)]
 pub trait CanRun<Code>: HasErrorType {
     async fn run(&self, _code: PhantomData<Code>) -> Result<(), Self::Error>;
 }
 
-#[cgp_component {
-    provider: SendRunner,
-    derive_delegate: UseDelegate<Code>,
-}]
+#[cgp_component(SendRunner)]
 #[async_trait]
+#[derive_delegate(UseDelegate<Code>)]
 pub trait CanSendRun<Code>: HasErrorType {
     fn send_run(
         &self,

--- a/crates/macros/cgp-macro-core/src/exports.rs
+++ b/crates/macros/cgp-macro-core/src/exports.rs
@@ -11,7 +11,9 @@ export_constructs! {
     RedirectLookup,
     DelegateComponent,
     IsProviderFor,
+    CanUseComponent,
     HasField,
     HasFieldMut,
     UseContext,
+    Life,
 }

--- a/crates/macros/cgp-macro-core/src/functions/is_provider_params.rs
+++ b/crates/macros/cgp-macro-core/src/functions/is_provider_params.rs
@@ -2,6 +2,7 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{GenericParam, Generics, Type};
 
+use crate::exports::Life;
 use crate::parse_internal;
 use crate::types::generics::TypeGenerics;
 
@@ -18,7 +19,7 @@ pub fn parse_is_provider_params(generics: &Generics) -> syn::Result<Punctuated<T
             }
             GenericParam::Lifetime(life_param) => {
                 let life = &life_param.lifetime;
-                parse_internal! { Life<#life> }
+                parse_internal! { #Life<#life> }
             }
             GenericParam::Const(_) => {
                 unimplemented!("const generic parameters are not yet supported in CGP traits")

--- a/crates/macros/cgp-macro-core/src/types/attributes/cgp_component_attributes.rs
+++ b/crates/macros/cgp-macro-core/src/types/attributes/cgp_component_attributes.rs
@@ -5,13 +5,17 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{Attribute, ItemTrait, TypeParamBound};
 
-use crate::types::attributes::{PrefixAttribute, UseTypeAttribute, UseTypeAttributes};
+use crate::types::attributes::{
+    DeriveDelegateAttribute, DeriveDelegateAttributes, PrefixAttribute, UseTypeAttribute,
+    UseTypeAttributes,
+};
 
 #[derive(Default, Clone)]
 pub struct CgpComponentAttributes {
     pub extend: Vec<TypeParamBound>,
     pub use_type: UseTypeAttributes,
     pub prefixes: Vec<PrefixAttribute>,
+    pub derive_delegate_attributes: DeriveDelegateAttributes,
 }
 
 impl CgpComponentAttributes {
@@ -57,6 +61,13 @@ impl CgpComponentAttributes {
                 } else if ident == "prefix" {
                     let namespace_specs = attribute.parse_args_with(PrefixAttribute::parse)?;
                     parsed_attributes.prefixes.push(namespace_specs);
+                } else if ident == "derive_delegate" {
+                    let derive_delegate_attribute =
+                        attribute.parse_args_with(DeriveDelegateAttribute::parse)?;
+                    parsed_attributes
+                        .derive_delegate_attributes
+                        .attributes
+                        .push(derive_delegate_attribute);
                 } else {
                     attributes.push(attribute);
                 }

--- a/crates/macros/cgp-macro-core/src/types/attributes/derive_delegate/attributes.rs
+++ b/crates/macros/cgp-macro-core/src/types/attributes/derive_delegate/attributes.rs
@@ -1,30 +1,6 @@
-use syn::bracketed;
-use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
-use syn::token::{Bracket, Comma};
-
 use crate::types::attributes::DeriveDelegateAttribute;
 
 #[derive(Default, Clone)]
 pub struct DeriveDelegateAttributes {
     pub attributes: Vec<DeriveDelegateAttribute>,
-}
-
-impl Parse for DeriveDelegateAttributes {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        if input.peek(Bracket) {
-            let body;
-            bracketed!(body in input);
-
-            let attributes = <Punctuated<DeriveDelegateAttribute, Comma>>::parse_terminated(&body)?;
-            Ok(Self {
-                attributes: Vec::from_iter(attributes),
-            })
-        } else {
-            let spec = input.parse()?;
-            Ok(Self {
-                attributes: vec![spec],
-            })
-        }
-    }
 }

--- a/crates/macros/cgp-macro-core/src/types/cgp_component/args/component_args.rs
+++ b/crates/macros/cgp-macro-core/src/types/cgp_component/args/component_args.rs
@@ -2,7 +2,6 @@ use proc_macro2::Span;
 use syn::parse::Parse;
 use syn::{Error, Ident};
 
-use crate::types::attributes::DeriveDelegateAttributes;
 use crate::types::cgp_component::CgpComponentRawArgs;
 use crate::types::ident::IdentWithTypeGenerics;
 
@@ -11,7 +10,6 @@ pub struct CgpComponentArgs {
     pub context_ident: Ident,
     pub provider_ident: Ident,
     pub component_name: IdentWithTypeGenerics,
-    pub derive_delegate_attributes: DeriveDelegateAttributes,
 }
 
 impl Parse for CgpComponentArgs {
@@ -41,13 +39,10 @@ impl TryFrom<CgpComponentRawArgs> for CgpComponentArgs {
             ))
         });
 
-        let derive_delegate_attributes = raw_args.derive_delegate_attributes.unwrap_or_default();
-
         Ok(Self {
             context_ident,
             provider_ident,
             component_name,
-            derive_delegate_attributes,
         })
     }
 }

--- a/crates/macros/cgp-macro-core/src/types/cgp_component/args/raw.rs
+++ b/crates/macros/cgp-macro-core/src/types/cgp_component/args/raw.rs
@@ -2,7 +2,6 @@ use syn::parse::{End, Parse, ParseStream};
 use syn::token::{Colon, Comma};
 use syn::{Error, Ident};
 
-use crate::types::attributes::DeriveDelegateAttributes;
 use crate::types::ident::IdentWithTypeGenerics;
 
 #[derive(Default)]
@@ -10,7 +9,6 @@ pub struct CgpComponentRawArgs {
     pub context_ident: Option<Ident>,
     pub provider_ident: Option<Ident>,
     pub component_name: Option<IdentWithTypeGenerics>,
-    pub derive_delegate_attributes: Option<DeriveDelegateAttributes>,
 }
 
 impl Parse for CgpComponentRawArgs {
@@ -52,12 +50,6 @@ impl Parse for CgpComponentRawArgs {
                     }
 
                     args.provider_ident = Some(input.parse()?);
-                }
-                "derive_delegate" => {
-                    if args.derive_delegate_attributes.is_some() {
-                        return Err(Error::new(key.span(), "duplicate key is not allowed"));
-                    }
-                    args.derive_delegate_attributes = Some(input.parse()?);
                 }
                 _ => {
                     return Err(Error::new(key.span(), format!("unknown key {key}")));

--- a/crates/macros/cgp-macro-core/src/types/cgp_component/evaluated/item.rs
+++ b/crates/macros/cgp-macro-core/src/types/cgp_component/evaluated/item.rs
@@ -60,7 +60,7 @@ impl EvaluatedCgpComponent {
         let component_type = self.args.component_name.to_type();
         let mut provider_impls = ItemProviderImpls::default();
 
-        for delegate_attribute in &self.args.derive_delegate_attributes.attributes {
+        for delegate_attribute in &self.attributes.derive_delegate_attributes.attributes {
             let item_impl = delegate_attribute.to_provider_impl(provider_trait)?;
             provider_impls.items.push(ItemProviderImpl {
                 component_type: component_type.clone(),

--- a/crates/macros/cgp-macro-core/src/types/cgp_component/item.rs
+++ b/crates/macros/cgp-macro-core/src/types/cgp_component/item.rs
@@ -10,12 +10,7 @@ pub struct ItemCgpComponent {
 
 impl ItemCgpComponent {
     pub fn preprocess(&self) -> syn::Result<PreprocessedCgpComponent> {
-        let (mut attributes, item_trait) = CgpComponentAttributes::preprocess(&self.item_trait)?;
-
-        attributes
-            .derive_delegate_attributes
-            .attributes
-            .extend(self.args.derive_delegate_attributes.attributes.clone());
+        let (attributes, item_trait) = CgpComponentAttributes::preprocess(&self.item_trait)?;
 
         Ok(PreprocessedCgpComponent {
             args: self.args.clone(),

--- a/crates/macros/cgp-macro-core/src/types/cgp_component/item.rs
+++ b/crates/macros/cgp-macro-core/src/types/cgp_component/item.rs
@@ -10,7 +10,12 @@ pub struct ItemCgpComponent {
 
 impl ItemCgpComponent {
     pub fn preprocess(&self) -> syn::Result<PreprocessedCgpComponent> {
-        let (attributes, item_trait) = CgpComponentAttributes::preprocess(&self.item_trait)?;
+        let (mut attributes, item_trait) = CgpComponentAttributes::preprocess(&self.item_trait)?;
+
+        attributes
+            .derive_delegate_attributes
+            .attributes
+            .extend(self.args.derive_delegate_attributes.attributes.clone());
 
         Ok(PreprocessedCgpComponent {
             args: self.args.clone(),

--- a/crates/macros/cgp-macro-core/src/types/cgp_provider/provider_impl_args.rs
+++ b/crates/macros/cgp-macro-core/src/types/cgp_provider/provider_impl_args.rs
@@ -5,6 +5,7 @@ use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{Error, Lifetime, Type};
 
+use crate::exports::Life;
 use crate::types::ident::{TypeArg, TypeArgs};
 
 pub struct ProviderImplArgs {
@@ -68,7 +69,7 @@ impl ToTokens for ProviderImplArg {
                 ty.to_tokens(tokens);
             }
             ProviderImplArg::Life(life) => {
-                tokens.extend(quote!(Life<#life>));
+                tokens.extend(quote!(#Life<#life>));
             }
         }
     }

--- a/crates/macros/cgp-macro-core/src/types/check_components/table.rs
+++ b/crates/macros/cgp-macro-core/src/types/check_components/table.rs
@@ -6,6 +6,7 @@ use syn::spanned::Spanned;
 use syn::token::{Comma, Lt, Pound, Where};
 use syn::{Attribute, Ident, Item, ItemImpl, ItemTrait, Type, WhereClause, braced, parse2};
 
+use crate::exports::CanUseComponent;
 use crate::functions::merge_generics;
 use crate::parse_internal;
 use crate::types::check_components::{CheckEntries, EvaluatedCheckEntry, TypeWithGenerics};
@@ -46,7 +47,7 @@ impl CheckComponentsTable {
             }
         } else {
             parse_internal! {
-                trait #trait_name <__Component__, __Params__: ?Sized>: CanUseComponent<__Component__, __Params__> {}
+                trait #trait_name <__Component__, __Params__: ?Sized>: #CanUseComponent<__Component__, __Params__> {}
             }
         };
 

--- a/crates/macros/cgp-macro-core/src/types/empty_struct.rs
+++ b/crates/macros/cgp-macro-core/src/types/empty_struct.rs
@@ -3,6 +3,8 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{GenericParam, Generics, Ident, ItemStruct, Type, parse_quote};
 
+use crate::exports::Life;
+
 pub struct EmptyStruct {
     pub ident: Ident,
     pub generics: Generics,
@@ -41,7 +43,7 @@ impl ToTokens for EmptyStruct {
                         life_param.bounds.clear();
 
                         let lifetime = &life_param.lifetime;
-                        phantom_params.push(parse_quote!( Life<#lifetime> ));
+                        phantom_params.push(parse_quote!( #Life<#lifetime> ));
                     }
                     _ => {}
                 }

--- a/crates/macros/cgp-macro-core/src/types/namespace/table.rs
+++ b/crates/macros/cgp-macro-core/src/types/namespace/table.rs
@@ -1,14 +1,14 @@
 use syn::parse::{Parse, ParseStream};
 use syn::token::Colon;
-use syn::{Error, Ident, ItemImpl, ItemStruct, ItemTrait, Type, braced};
+use syn::{Ident, ItemImpl, ItemStruct, ItemTrait, Type, braced};
 
-use crate::parse_internal;
+use crate::functions::parse_internal;
 use crate::traits::ParseOptionalKeyword;
 use crate::types::delegate_component::{
     DelegateEntries, EvalDelegateEntries, EvalDelegateEntry, EvalForEntry,
 };
 use crate::types::generics::ImplGenerics;
-use crate::types::ident::{IdentWithTypeGenerics, PathWithTypeArgs};
+use crate::types::ident::{IdentWithTypeArgs, PathWithTypeArgs};
 use crate::types::keyword::Keyword;
 use crate::types::keywords::New;
 use crate::types::namespace::{EvaluatedNamespaceTable, InheritNamespaceStatement};
@@ -16,7 +16,7 @@ use crate::types::namespace::{EvaluatedNamespaceTable, InheritNamespaceStatement
 pub struct NamespaceTable {
     pub impl_generics: ImplGenerics,
     pub new: Option<Keyword<New>>,
-    pub namespace: IdentWithTypeGenerics,
+    pub namespace: IdentWithTypeArgs,
     pub parent_namespace: Option<(Colon, PathWithTypeArgs)>,
     pub entries: DelegateEntries,
 }
@@ -55,11 +55,11 @@ impl Parse for NamespaceTable {
 
 impl NamespaceTable {
     pub fn build_namespace_trait(&self) -> syn::Result<Type> {
-        let namespace_ident = &self.namespace.ident;
-        let mut namespace_generics = self.namespace.type_generics.clone();
-        namespace_generics.params.push(parse_internal!(__Table__));
+        let mut namespace = self.namespace.clone();
 
-        let namespace_trait: Type = parse_internal!( #namespace_ident #namespace_generics );
+        namespace.type_args.args.push(parse_internal!(__Table__));
+
+        let namespace_trait: Type = parse_internal!( #namespace );
         Ok(namespace_trait)
     }
 
@@ -102,21 +102,12 @@ impl NamespaceTable {
         Ok(item_impls)
     }
 
-    pub fn build_parent_namespace_impl(&self) -> syn::Result<Option<(ItemStruct, ItemImpl)>> {
-        let Some((_, parent_namespace)) = &self.parent_namespace else {
-            return Ok(None);
-        };
-
+    pub fn build_namespace_struct(&self) -> syn::Result<Option<ItemStruct>> {
         if self.new.is_none() {
-            return Err(Error::new(
-                parent_namespace.ident().span(),
-                "parent namespace can only be specified with `new` namespaces",
-            ));
+            return Ok(None);
         }
 
-        let namespace_ident = self.namespace.ident.clone();
-
-        let table_type: Type = parse_internal!(__Table__);
+        let namespace_ident = &self.namespace.ident;
 
         let namespace_struct_ident = Ident::new(
             &format!("__{}Components", namespace_ident),
@@ -126,6 +117,23 @@ impl NamespaceTable {
         let namespace_struct: ItemStruct = parse_internal! {
             pub struct #namespace_struct_ident;
         };
+
+        Ok(Some(namespace_struct))
+    }
+
+    pub fn build_parent_namespace_impl(&self) -> syn::Result<Option<ItemImpl>> {
+        let Some((_, parent_namespace)) = &self.parent_namespace else {
+            return Ok(None);
+        };
+
+        let namespace_ident = self.namespace.ident.clone();
+
+        let table_type: Type = parse_internal!(__Table__);
+
+        let namespace_struct_ident = Ident::new(
+            &format!("__{}Components", namespace_ident),
+            namespace_ident.span(),
+        );
 
         let for_entry = InheritNamespaceStatement {
             namespace: parent_namespace.clone(),
@@ -142,17 +150,16 @@ impl NamespaceTable {
 
         let item_impl = evaluated_entry.build_namespace_impl(&namespace_trait, &generics)?;
 
-        Ok(Some((namespace_struct, item_impl)))
+        Ok(Some(item_impl))
     }
 
     pub fn eval(&self) -> syn::Result<EvaluatedNamespaceTable> {
-        let mut item_struct = None;
         let item_trait = self.build_item_trait()?;
         let mut item_impls = self.build_item_impls()?;
+        let item_struct = self.build_namespace_struct()?;
 
-        if let Some((namespace_struct, item_impl)) = self.build_parent_namespace_impl()? {
+        if let Some(item_impl) = self.build_parent_namespace_impl()? {
             item_impls.insert(0, item_impl);
-            item_struct = Some(namespace_struct);
         }
 
         Ok(EvaluatedNamespaceTable {

--- a/crates/macros/cgp-macro-core/src/types/path/mod.rs
+++ b/crates/macros/cgp-macro-core/src/types/path/mod.rs
@@ -1,4 +1,5 @@
 mod path_element;
+mod path_element_with_generics;
 mod path_head;
 mod path_head_or_type;
 mod prefix;
@@ -6,6 +7,7 @@ mod unipath;
 mod unipath_or_type;
 
 pub use path_element::*;
+pub use path_element_with_generics::*;
 pub use path_head::*;
 pub use path_head_or_type::*;
 pub use prefix::*;

--- a/crates/macros/cgp-macro-core/src/types/path/path_element_with_generics.rs
+++ b/crates/macros/cgp-macro-core/src/types/path/path_element_with_generics.rs
@@ -1,0 +1,18 @@
+use syn::parse::{Parse, ParseStream};
+
+use crate::types::generics::ImplGenerics;
+use crate::types::path::PathElement;
+
+#[derive(Debug, Clone)]
+pub struct PathElementWithGenerics {
+    pub generics: ImplGenerics,
+    pub element: PathElement,
+}
+
+impl Parse for PathElementWithGenerics {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let generics = input.parse()?;
+        let element = input.parse()?;
+        Ok(Self { generics, element })
+    }
+}

--- a/crates/macros/cgp-macro-core/src/types/path/path_head.rs
+++ b/crates/macros/cgp-macro-core/src/types/path/path_head.rs
@@ -1,7 +1,7 @@
-use syn::braced;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::token::{Brace, Comma, Dot};
+use syn::token::{Brace, Bracket, Comma, Dot};
+use syn::{braced, bracketed};
 
 use crate::types::generics::ImplGenerics;
 use crate::types::path::{PathElement, UniPath};
@@ -9,7 +9,8 @@ use crate::types::path::{PathElement, UniPath};
 #[derive(Debug, Clone)]
 pub enum PathHead {
     Type(ImplGenerics, Box<PathElement>, Box<PathHead>),
-    Group(Punctuated<PathHead, Comma>),
+    Nested(Punctuated<PathHead, Comma>),
+    Group(Punctuated<PathElement, Comma>, Box<PathHead>),
     End,
 }
 
@@ -29,10 +30,24 @@ impl PathHead {
 
                 out_paths
             }
-            Self::Group(path_heads) => path_heads
+            Self::Nested(path_heads) => path_heads
                 .iter()
                 .flat_map(|path| path.into_paths())
                 .collect(),
+            Self::Group(path_elements, tail) => {
+                let tail_paths = tail.into_paths();
+                let mut out_paths = Vec::new();
+
+                for path_element in path_elements {
+                    for (tail_generics, tail_path) in &tail_paths {
+                        let mut path = tail_path.clone();
+                        path.elements.insert(0, path_element.clone());
+                        out_paths.push((tail_generics.clone(), path));
+                    }
+                }
+
+                out_paths
+            }
             Self::End => {
                 vec![(ImplGenerics::default(), UniPath::default())]
             }
@@ -50,7 +65,21 @@ impl Parse for PathHead {
 
             let group = Punctuated::parse_terminated(&body)?;
 
-            Ok(Self::Group(group))
+            Ok(Self::Nested(group))
+        } else if input.peek(Bracket) {
+            let body;
+            bracketed!(body in input);
+
+            let group = Punctuated::parse_terminated(&body)?;
+
+            let rest_path = if input.peek(Dot) {
+                let _: Dot = input.parse()?;
+                Box::new(Self::parse(input)?)
+            } else {
+                Box::new(Self::End)
+            };
+
+            Ok(Self::Group(group, rest_path))
         } else {
             let generics = input.parse()?;
 

--- a/crates/macros/cgp-macro-core/src/types/path/path_head.rs
+++ b/crates/macros/cgp-macro-core/src/types/path/path_head.rs
@@ -4,27 +4,30 @@ use syn::token::{Brace, Bracket, Comma, Dot};
 use syn::{braced, bracketed};
 
 use crate::types::generics::ImplGenerics;
-use crate::types::path::{PathElement, UniPath};
+use crate::types::path::{PathElementWithGenerics, UniPath};
 
 #[derive(Debug, Clone)]
 pub enum PathHead {
-    Type(ImplGenerics, Box<PathElement>, Box<PathHead>),
+    Type(Box<PathElementWithGenerics>, Box<PathHead>),
     Nested(Punctuated<PathHead, Comma>),
-    Group(Punctuated<PathElement, Comma>, Box<PathHead>),
+    Group(Punctuated<PathElementWithGenerics, Comma>, Box<PathHead>),
     End,
 }
 
 impl PathHead {
     pub fn into_paths(&self) -> Vec<(ImplGenerics, UniPath)> {
         match self {
-            Self::Type(generics, path_element, tail) => {
+            Self::Type(path_element, tail) => {
+                let generics = &path_element.generics;
+                let element = &path_element.element;
+
                 let tail_paths = tail.into_paths();
                 let mut out_paths = Vec::new();
 
                 for (tail_generics, mut tail_path) in tail_paths {
                     let mut generics = generics.clone();
                     generics.params.extend(tail_generics.params.iter().cloned());
-                    tail_path.elements.insert(0, path_element.as_ref().clone());
+                    tail_path.elements.insert(0, element.clone());
                     out_paths.push((generics, tail_path))
                 }
 
@@ -40,9 +43,12 @@ impl PathHead {
 
                 for path_element in path_elements {
                     for (tail_generics, tail_path) in &tail_paths {
+                        let mut generics = path_element.generics.clone();
+                        generics.params.extend(tail_generics.params.iter().cloned());
+
                         let mut path = tail_path.clone();
-                        path.elements.insert(0, path_element.clone());
-                        out_paths.push((tail_generics.clone(), path));
+                        path.elements.insert(0, path_element.element.clone());
+                        out_paths.push((generics, path));
                     }
                 }
 
@@ -81,9 +87,7 @@ impl Parse for PathHead {
 
             Ok(Self::Group(group, rest_path))
         } else {
-            let generics = input.parse()?;
-
-            let path_type: PathElement = input.parse()?;
+            let path_element = input.parse()?;
 
             let rest_path = if input.peek(Dot) {
                 let _: Dot = input.parse()?;
@@ -92,7 +96,7 @@ impl Parse for PathHead {
                 Box::new(Self::End)
             };
 
-            Ok(Self::Type(generics, Box::new(path_type), rest_path))
+            Ok(Self::Type(Box::new(path_element), rest_path))
         }
     }
 }

--- a/crates/macros/cgp-macro-lib/src/entrypoints/mod.rs
+++ b/crates/macros/cgp-macro-lib/src/entrypoints/mod.rs
@@ -20,6 +20,7 @@ mod derive_build_field;
 mod derive_extract_field;
 mod derive_from_variant;
 mod derive_has_fields;
+mod path;
 mod re_export_imports;
 mod replace_with;
 
@@ -45,5 +46,6 @@ pub use derive_build_field::*;
 pub use derive_extract_field::*;
 pub use derive_from_variant::*;
 pub use derive_has_fields::*;
+pub use path::*;
 pub use re_export_imports::*;
 pub use replace_with::*;

--- a/crates/macros/cgp-macro-lib/src/entrypoints/path.rs
+++ b/crates/macros/cgp-macro-lib/src/entrypoints/path.rs
@@ -1,0 +1,9 @@
+use cgp_macro_core::types::path::UniPath;
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::parse2;
+
+pub fn path(body: TokenStream) -> syn::Result<TokenStream> {
+    let unipath: UniPath = parse2(body)?;
+    Ok(unipath.to_token_stream())
+}

--- a/crates/macros/cgp-macro-lib/src/parse/path.rs
+++ b/crates/macros/cgp-macro-lib/src/parse/path.rs
@@ -34,6 +34,7 @@ impl Parse for ComponentPaths {
     }
 }
 
+#[derive(Clone)]
 pub struct ComponentPath<Path> {
     pub path_type: Path,
     pub generics: ImplGenerics,
@@ -46,7 +47,22 @@ pub fn path_head_to_prefix(path_head: &PathHead) -> Vec<ComponentPath<TokenStrea
 
             prepend_path(path_type.to_token_stream(), generics.clone(), rest_types)
         }
-        PathHead::Group(paths) => paths.iter().flat_map(path_head_to_prefix).collect(),
+        PathHead::Group(path_elements, rest) => {
+            let rest_types = path_head_to_prefix(rest);
+            let mut out = Vec::new();
+
+            for path_element in path_elements {
+                let paths = prepend_path(
+                    path_element.to_token_stream(),
+                    Default::default(),
+                    rest_types.clone(),
+                );
+                out.extend(paths);
+            }
+
+            out
+        }
+        PathHead::Nested(paths) => paths.iter().flat_map(path_head_to_prefix).collect(),
         PathHead::End => {
             vec![ComponentPath {
                 path_type: quote! { __Wildcard__ },

--- a/crates/macros/cgp-macro-lib/src/parse/path.rs
+++ b/crates/macros/cgp-macro-lib/src/parse/path.rs
@@ -42,10 +42,14 @@ pub struct ComponentPath<Path> {
 
 pub fn path_head_to_prefix(path_head: &PathHead) -> Vec<ComponentPath<TokenStream>> {
     match path_head {
-        PathHead::Type(generics, path_type, rest) => {
+        PathHead::Type(path_element, rest) => {
             let rest_types = path_head_to_prefix(rest);
 
-            prepend_path(path_type.to_token_stream(), generics.clone(), rest_types)
+            prepend_path(
+                path_element.element.to_token_stream(),
+                path_element.generics.clone(),
+                rest_types,
+            )
         }
         PathHead::Group(path_elements, rest) => {
             let rest_types = path_head_to_prefix(rest);
@@ -53,8 +57,8 @@ pub fn path_head_to_prefix(path_head: &PathHead) -> Vec<ComponentPath<TokenStrea
 
             for path_element in path_elements {
                 let paths = prepend_path(
-                    path_element.to_token_stream(),
-                    Default::default(),
+                    path_element.element.to_token_stream(),
+                    path_element.generics.clone(),
                     rest_types.clone(),
                 );
                 out.extend(paths);

--- a/crates/macros/cgp-macro-test-util/README.md
+++ b/crates/macros/cgp-macro-test-util/README.md
@@ -285,7 +285,7 @@ snapshot_cgp_type! {
 
 Both the default form `#[cgp_type]` and the custom provider name forms
 `#[cgp_type(ScalarTypeProvider)]` and
-`#[cgp_type { provider: ..., derive_delegate: ... }]` are accepted, mirroring the
+`#[cgp_type { provider: ... }]` are accepted, mirroring the
 real macro. In addition to the usual `#[cgp_component]` output, the snapshot
 captures the extra `UseType` / `WithProvider` providers that `#[cgp_type]`
 generates.

--- a/crates/macros/cgp-macro/src/lib.rs
+++ b/crates/macros/cgp-macro/src/lib.rs
@@ -973,6 +973,14 @@ pub fn Sum(body: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
+#[allow(non_snake_case)]
+pub fn Path(body: TokenStream) -> TokenStream {
+    cgp_macro_lib::path(body.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro]
 pub fn product(body: TokenStream) -> TokenStream {
     cgp_macro_lib::make_product_expr(body.into()).into()
 }

--- a/crates/macros/cgp-macro/src/lib.rs
+++ b/crates/macros/cgp-macro/src/lib.rs
@@ -25,10 +25,6 @@ use proc_macro::TokenStream;
     - `context` - the identifier used for the generic context type. If not provided,
       the default identifier `Context` would be used.
 
-    - `derive_delegate` - a list of generic dispatcher wrappers to derive the
-      `UseDelegate` pattern on, with the matching generic parameters specified in
-      the generic argument of the wrapper. Refer to `UseDelegate` for more details.
-
     ## Extension Macros
 
     There are two other macros that extends `#[cgp_component]` that can be used for

--- a/crates/tests/cgp-tests/src/namespaces/default_impls.rs
+++ b/crates/tests/cgp-tests/src/namespaces/default_impls.rs
@@ -162,6 +162,7 @@ snapshot_cgp_namespace! {
 
     expand_default_show_components(output) {
         insta::assert_snapshot!(output, @"
+        pub struct __DefaultShowComponentsComponents;
         pub trait DefaultShowComponents<__Table__> {
             type Delegate;
         }

--- a/crates/tests/cgp-tests/src/tests/use_delegate/getter.rs
+++ b/crates/tests/cgp-tests/src/tests/use_delegate/getter.rs
@@ -6,13 +6,9 @@ use cgp_macro_test_util::{snapshot_cgp_getter, snapshot_cgp_type};
 pub struct UseDelegate2<Components>(pub PhantomData<Components>);
 
 snapshot_cgp_type! {
-    #[cgp_type {
-        provider: FooTypeProviderAt,
-        derive_delegate: [
-            UseDelegate<I>,
-            UseDelegate2<(I, J)>,
-        ],
-    }]
+    #[cgp_type(FooTypeProviderAt)]
+    #[derive_delegate(UseDelegate<I>)]
+    #[derive_delegate(UseDelegate2<(I, J)>)]
     pub trait HasFooTypeAt<I, J> {
         type Foo;
     }
@@ -185,13 +181,9 @@ snapshot_cgp_type! {
 }
 
 snapshot_cgp_getter! {
-    #[cgp_getter {
-        provider: FooGetterAt,
-        derive_delegate: [
-            UseDelegate<I>,
-            UseDelegate2<(I, J)>,
-        ],
-    }]
+    #[cgp_getter(FooGetterAt)]
+    #[derive_delegate(UseDelegate<I>)]
+    #[derive_delegate(UseDelegate2<(I, J)>)]
     pub trait HasFooAt<I, J>: HasFooTypeAt<I, J> {
         fn foo_at(&self, _tag: PhantomData<(I, J)>) -> &Self::Foo;
     }

--- a/crates/tests/cgp-tests/tests/namespace_tests/group.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/group.rs
@@ -1,0 +1,195 @@
+use cgp::prelude::{DefaultNamespace, cgp_component, cgp_impl, check_components};
+use cgp_macro_test_util::snapshot_delegate_components;
+
+#[cgp_component(FooProvider)]
+#[prefix(@app in DefaultNamespace)]
+pub trait Foo<T> {
+    fn foo(&self, value: &T);
+}
+
+#[cgp_component(BarProvider)]
+#[prefix(@app in DefaultNamespace)]
+pub trait Bar<T> {
+    fn bar(&self, value: &T);
+}
+
+pub struct DummyImpl;
+
+#[cgp_impl(DummyImpl)]
+impl<T> FooProvider<T> {
+    fn foo(&self, _value: &T) {}
+}
+
+#[cgp_impl(DummyImpl)]
+impl<T> BarProvider<T> {
+    fn bar(&self, _value: &T) {}
+}
+
+pub struct App;
+
+snapshot_delegate_components! {
+    delegate_components! {
+        App {
+            namespace DefaultNamespace;
+
+            @app.[FooProviderComponent, BarProviderComponent].[u64, String]:
+                DummyImpl,
+        }
+    }
+
+    expand_delegate_components(output) {
+        insta::assert_snapshot!(output, @"
+        impl<__Key__, __Value__> DelegateComponent<__Key__> for App
+        where
+            __Key__: DefaultNamespace<App, Delegate = __Value__>,
+        {
+            type Delegate = __Value__;
+        }
+        impl<
+            __Key__,
+            __Value__,
+            __Context__,
+            __Params__,
+        > IsProviderFor<__Key__, __Context__, __Params__> for App
+        where
+            __Key__: DefaultNamespace<App, Delegate = __Value__>,
+            __Value__: IsProviderFor<__Key__, __Context__, __Params__>,
+        {}
+        impl<
+            __Wildcard__,
+        > DelegateComponent<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<FooProviderComponent, PathCons<u64, __Wildcard__>>,
+            >,
+        > for App {
+            type Delegate = DummyImpl;
+        }
+        impl<
+            __Wildcard__,
+            __Context__,
+            __Params__,
+        > IsProviderFor<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<FooProviderComponent, PathCons<u64, __Wildcard__>>,
+            >,
+            __Context__,
+            __Params__,
+        > for App
+        where
+            DummyImpl: IsProviderFor<
+                PathCons<
+                    Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                    PathCons<FooProviderComponent, PathCons<u64, __Wildcard__>>,
+                >,
+                __Context__,
+                __Params__,
+            >,
+        {}
+        impl<
+            __Wildcard__,
+        > DelegateComponent<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<FooProviderComponent, PathCons<String, __Wildcard__>>,
+            >,
+        > for App {
+            type Delegate = DummyImpl;
+        }
+        impl<
+            __Wildcard__,
+            __Context__,
+            __Params__,
+        > IsProviderFor<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<FooProviderComponent, PathCons<String, __Wildcard__>>,
+            >,
+            __Context__,
+            __Params__,
+        > for App
+        where
+            DummyImpl: IsProviderFor<
+                PathCons<
+                    Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                    PathCons<FooProviderComponent, PathCons<String, __Wildcard__>>,
+                >,
+                __Context__,
+                __Params__,
+            >,
+        {}
+        impl<
+            __Wildcard__,
+        > DelegateComponent<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<BarProviderComponent, PathCons<u64, __Wildcard__>>,
+            >,
+        > for App {
+            type Delegate = DummyImpl;
+        }
+        impl<
+            __Wildcard__,
+            __Context__,
+            __Params__,
+        > IsProviderFor<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<BarProviderComponent, PathCons<u64, __Wildcard__>>,
+            >,
+            __Context__,
+            __Params__,
+        > for App
+        where
+            DummyImpl: IsProviderFor<
+                PathCons<
+                    Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                    PathCons<BarProviderComponent, PathCons<u64, __Wildcard__>>,
+                >,
+                __Context__,
+                __Params__,
+            >,
+        {}
+        impl<
+            __Wildcard__,
+        > DelegateComponent<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<BarProviderComponent, PathCons<String, __Wildcard__>>,
+            >,
+        > for App {
+            type Delegate = DummyImpl;
+        }
+        impl<
+            __Wildcard__,
+            __Context__,
+            __Params__,
+        > IsProviderFor<
+            PathCons<
+                Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                PathCons<BarProviderComponent, PathCons<String, __Wildcard__>>,
+            >,
+            __Context__,
+            __Params__,
+        > for App
+        where
+            DummyImpl: IsProviderFor<
+                PathCons<
+                    Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
+                    PathCons<BarProviderComponent, PathCons<String, __Wildcard__>>,
+                >,
+                __Context__,
+                __Params__,
+            >,
+        {}
+        ")
+    }
+}
+
+check_components! {
+    App {
+        [FooProviderComponent, BarProviderComponent]:
+            [u64, String]
+    }
+}

--- a/crates/tests/cgp-tests/tests/namespace_tests/mod.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod group;
 pub mod multi_param;
 pub mod namespace;
 pub mod namespace_macro;

--- a/crates/tests/cgp-tests/tests/namespace_tests/multi_param.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/multi_param.rs
@@ -1,138 +1,15 @@
 use cgp::prelude::*;
-use cgp_macro_test_util::{
-    snapshot_cgp_component, snapshot_cgp_impl, snapshot_check_components,
-    snapshot_delegate_components,
-};
+use cgp_macro_test_util::{snapshot_check_components, snapshot_delegate_components};
 
-snapshot_cgp_component! {
-    #[cgp_component(FooProvider)]
-    #[prefix(@app in DefaultNamespace)]
-    pub trait Foo<'a, T, U> {
-        fn foo(&self, first: &'a T, second: U);
-    }
-
-    expand_multi_param_foo(output) {
-        insta::assert_snapshot!(output, @"
-        pub trait Foo<'a, T, U> {
-            fn foo(&self, first: &'a T, second: U);
-        }
-        impl<'a, __Context__, T, U> Foo<'a, T, U> for __Context__
-        where
-            __Context__: FooProvider<'a, __Context__, T, U>,
-        {
-            fn foo(&self, first: &'a T, second: U) {
-                __Context__::foo(self, first, second)
-            }
-        }
-        pub trait FooProvider<
-            'a,
-            __Context__,
-            T,
-            U,
-        >: IsProviderFor<FooProviderComponent, __Context__, (Life<'a>, T, U)> {
-            fn foo(__context__: &__Context__, first: &'a T, second: U);
-        }
-        impl<'a, __Provider__, __Context__, T, U> FooProvider<'a, __Context__, T, U>
-        for __Provider__
-        where
-            __Provider__: DelegateComponent<FooProviderComponent>
-                + IsProviderFor<FooProviderComponent, __Context__, (Life<'a>, T, U)>,
-            <__Provider__ as DelegateComponent<
-                FooProviderComponent,
-            >>::Delegate: FooProvider<'a, __Context__, T, U>,
-        {
-            fn foo(__context__: &__Context__, first: &'a T, second: U) {
-                <__Provider__ as DelegateComponent<
-                    FooProviderComponent,
-                >>::Delegate::foo(__context__, first, second)
-            }
-        }
-        pub struct FooProviderComponent;
-        impl<'a, __Context__, T, U> FooProvider<'a, __Context__, T, U> for UseContext
-        where
-            __Context__: Foo<'a, T, U>,
-        {
-            fn foo(__context__: &__Context__, first: &'a T, second: U) {
-                __Context__::foo(__context__, first, second)
-            }
-        }
-        impl<
-            'a,
-            __Context__,
-            T,
-            U,
-        > IsProviderFor<FooProviderComponent, __Context__, (Life<'a>, T, U)> for UseContext
-        where
-            __Context__: Foo<'a, T, U>,
-        {}
-        impl<'a, __Context__, T, U, __Components__, __Path__> FooProvider<'a, __Context__, T, U>
-        for RedirectLookup<__Components__, __Path__>
-        where
-            __Path__: ConcatPath<PathCons<T, PathCons<U, Nil>>>,
-            __Components__: DelegateComponent<
-                <__Path__ as ConcatPath<PathCons<T, PathCons<U, Nil>>>>::Output,
-            >,
-            <__Components__ as DelegateComponent<
-                <__Path__ as ConcatPath<PathCons<T, PathCons<U, Nil>>>>::Output,
-            >>::Delegate: FooProvider<'a, __Context__, T, U>,
-        {
-            fn foo(__context__: &__Context__, first: &'a T, second: U) {
-                <__Components__ as DelegateComponent<
-                    <__Path__ as ConcatPath<PathCons<T, PathCons<U, Nil>>>>::Output,
-                >>::Delegate::foo(__context__, first, second)
-            }
-        }
-        impl<
-            'a,
-            __Context__,
-            T,
-            U,
-            __Components__,
-            __Path__,
-        > IsProviderFor<FooProviderComponent, __Context__, (Life<'a>, T, U)>
-        for RedirectLookup<__Components__, __Path__>
-        where
-            __Path__: ConcatPath<PathCons<T, PathCons<U, Nil>>>,
-            __Components__: DelegateComponent<
-                <__Path__ as ConcatPath<PathCons<T, PathCons<U, Nil>>>>::Output,
-            >,
-            <__Components__ as DelegateComponent<
-                <__Path__ as ConcatPath<PathCons<T, PathCons<U, Nil>>>>::Output,
-            >>::Delegate: FooProvider<'a, __Context__, T, U>,
-        {}
-        impl<__Components__> DefaultNamespace<__Components__> for FooProviderComponent {
-            type Delegate = RedirectLookup<
-                __Components__,
-                PathCons<
-                    Symbol<3, Chars<'a', Chars<'p', Chars<'p', Nil>>>>,
-                    PathCons<FooProviderComponent, Nil>,
-                >,
-            >;
-        }
-        ")
-    }
+#[cgp_component(FooProvider)]
+#[prefix(@app in DefaultNamespace)]
+pub trait Foo<'a, T, U> {
+    fn foo(&self, first: &'a T, second: U);
 }
 
-snapshot_cgp_impl! {
-    #[cgp_impl(new DummyFoo)]
-    impl<'a, T, U> FooProvider<'a, T, U> {
-        fn foo(&self, _first: &'a T, _second: U) {}
-    }
-
-    expand_multi_param_dummy_foo(output) {
-        insta::assert_snapshot!(output, @"
-        impl<'a, __Context__, T, U> FooProvider<'a, __Context__, T, U> for DummyFoo {
-            fn foo(__context__: &__Context__, _first: &'a T, _second: U) {}
-        }
-        impl<
-            'a,
-            __Context__,
-            T,
-            U,
-        > IsProviderFor<FooProviderComponent, __Context__, (Life<'a>, T, U)> for DummyFoo {}
-        pub struct DummyFoo;
-        ")
-    }
+#[cgp_impl(new DummyFoo)]
+impl<'a, T, U> FooProvider<'a, T, U> {
+    fn foo(&self, _first: &'a T, _second: U) {}
 }
 
 pub struct AppA;

--- a/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/basic.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/basic.rs
@@ -1,4 +1,3 @@
-use cgp::prelude::*;
 use cgp_macro_test_util::{
     snapshot_cgp_component, snapshot_cgp_impl, snapshot_cgp_namespace, snapshot_check_components,
     snapshot_delegate_components,
@@ -92,6 +91,7 @@ snapshot_cgp_namespace! {
 
     expand_basic_my_namespace(output) {
         insta::assert_snapshot!(output, @"
+        pub struct __MyNamespaceComponents;
         pub trait MyNamespace<__Table__> {
             type Delegate;
         }

--- a/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/extended_namespace.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/extended_namespace.rs
@@ -19,7 +19,7 @@ snapshot_delegate_components! {
                 ErrorWrapperComponent,
             }:
                 RaiseFrom,
-            TryComputerComponent:
+            @cgp.extra.handler.TryComputerComponent:
                 Foo,
         }
     }

--- a/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/extended_namespace.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/extended_namespace.rs
@@ -172,15 +172,94 @@ snapshot_delegate_components! {
                 __Params__,
             >,
         {}
-        impl DelegateComponent<TryComputerComponent> for App {
+        impl<
+            __Wildcard__,
+        > DelegateComponent<
+            PathCons<
+                Symbol<3, Chars<'c', Chars<'g', Chars<'p', Nil>>>>,
+                PathCons<
+                    Symbol<5, Chars<'e', Chars<'x', Chars<'t', Chars<'r', Chars<'a', Nil>>>>>>,
+                    PathCons<
+                        Symbol<
+                            7,
+                            Chars<
+                                'h',
+                                Chars<
+                                    'a',
+                                    Chars<
+                                        'n',
+                                        Chars<'d', Chars<'l', Chars<'e', Chars<'r', Nil>>>>,
+                                    >,
+                                >,
+                            >,
+                        >,
+                        PathCons<TryComputerComponent, __Wildcard__>,
+                    >,
+                >,
+            >,
+        > for App {
             type Delegate = Foo;
         }
         impl<
+            __Wildcard__,
             __Context__,
             __Params__,
-        > IsProviderFor<TryComputerComponent, __Context__, __Params__> for App
+        > IsProviderFor<
+            PathCons<
+                Symbol<3, Chars<'c', Chars<'g', Chars<'p', Nil>>>>,
+                PathCons<
+                    Symbol<5, Chars<'e', Chars<'x', Chars<'t', Chars<'r', Chars<'a', Nil>>>>>>,
+                    PathCons<
+                        Symbol<
+                            7,
+                            Chars<
+                                'h',
+                                Chars<
+                                    'a',
+                                    Chars<
+                                        'n',
+                                        Chars<'d', Chars<'l', Chars<'e', Chars<'r', Nil>>>>,
+                                    >,
+                                >,
+                            >,
+                        >,
+                        PathCons<TryComputerComponent, __Wildcard__>,
+                    >,
+                >,
+            >,
+            __Context__,
+            __Params__,
+        > for App
         where
-            Foo: IsProviderFor<TryComputerComponent, __Context__, __Params__>,
+            Foo: IsProviderFor<
+                PathCons<
+                    Symbol<3, Chars<'c', Chars<'g', Chars<'p', Nil>>>>,
+                    PathCons<
+                        Symbol<
+                            5,
+                            Chars<'e', Chars<'x', Chars<'t', Chars<'r', Chars<'a', Nil>>>>>,
+                        >,
+                        PathCons<
+                            Symbol<
+                                7,
+                                Chars<
+                                    'h',
+                                    Chars<
+                                        'a',
+                                        Chars<
+                                            'n',
+                                            Chars<'d', Chars<'l', Chars<'e', Chars<'r', Nil>>>>,
+                                        >,
+                                    >,
+                                >,
+                            >,
+                            PathCons<TryComputerComponent, __Wildcard__>,
+                        >,
+                    >,
+                >,
+                __Context__,
+                __Params__,
+            >,
         {}
         ")
     }

--- a/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/multi_namespace.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/multi_namespace.rs
@@ -1,4 +1,3 @@
-use cgp::prelude::*;
 use cgp_macro_test_util::{
     snapshot_cgp_component, snapshot_cgp_impl, snapshot_cgp_namespace, snapshot_check_components,
     snapshot_delegate_components,
@@ -94,6 +93,7 @@ snapshot_cgp_namespace! {
 
     expand_multi_ns_my_namespace(output) {
         insta::assert_snapshot!(output, @"
+        pub struct __MyNamespaceComponents;
         pub trait MyNamespace<__Table__> {
             type Delegate;
         }
@@ -117,6 +117,7 @@ snapshot_cgp_namespace! {
 
     expand_multi_ns_other_namespace(output) {
         insta::assert_snapshot!(output, @"
+        pub struct __OtherNamespaceComponents;
         pub trait OtherNamespace<__Table__> {
             type Delegate;
         }

--- a/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/symbol_path.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/symbol_path.rs
@@ -1,4 +1,3 @@
-use cgp::prelude::*;
 use cgp_macro_test_util::{
     snapshot_cgp_component, snapshot_cgp_impl, snapshot_cgp_namespace, snapshot_check_components,
     snapshot_delegate_components,
@@ -92,6 +91,7 @@ snapshot_cgp_namespace! {
 
     expand_symbol_path_my_namespace(output) {
         insta::assert_snapshot!(output, @"
+        pub struct __MyNamespaceComponents;
         pub trait MyNamespace<__Table__> {
             type Delegate;
         }

--- a/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/type_path.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/namespace_macro/type_path.rs
@@ -1,4 +1,3 @@
-use cgp::prelude::*;
 use cgp_macro_test_util::{
     snapshot_cgp_component, snapshot_cgp_impl, snapshot_cgp_namespace, snapshot_check_components,
     snapshot_delegate_components,
@@ -94,6 +93,7 @@ snapshot_cgp_namespace! {
 
     expand_type_path_my_namespace(output) {
         insta::assert_snapshot!(output, @"
+        pub struct __MyNamespaceComponents;
         pub trait MyNamespace<__Table__> {
             type Delegate;
         }

--- a/crates/tests/cgp-tests/tests/namespace_tests/open.rs
+++ b/crates/tests/cgp-tests/tests/namespace_tests/open.rs
@@ -1,4 +1,3 @@
-use cgp::prelude::*;
 use cgp_macro_test_util::{
     snapshot_cgp_component, snapshot_cgp_impl, snapshot_check_components,
     snapshot_delegate_components,


### PR DESCRIPTION
# AI Overview

This PR reworks how CGP's namespace and path machinery is configured and expanded, and pulls `derive_delegate` out of the `#[cgp_component]` argument block into a standalone attribute. The headline change is **grouped paths** — a syntax that lets one delegation entry expand into the cartesian product of several path elements. Alongside it are a cluster of supporting refactors: the `derive_delegate` configuration moves to its own attribute, namespace-struct generation is decoupled from parent-namespace inheritance, and several macro-internal references are now resolved through the crate's export table rather than bare identifiers. The user-facing surface is small; most of the work is in the proc-macro core.

## High-level concepts

The central new idea is that a single path key can name a *set* of components and a *set* of parameters at once. Where you previously wrote one delegation line per component, you can now write `@app.[FooComponent, BarComponent].[u64, String]: DummyImpl` and have the macro expand it into all four combinations (`Foo×u64`, `Foo×String`, `Bar×u64`, `Bar×String`). This is purely an expansion-time convenience — each combination still produces an independent `DelegateComponent` and `IsProviderFor` impl, exactly as if you had written them out by hand. The grouping composes, so two bracketed groups chained with `.` multiply together.

The second concept is that `derive_delegate` is now an ordinary attribute rather than a key inside the `#[cgp_component { ... }]` brace block. Instead of `#[cgp_component { provider: ErrorRaiser, derive_delegate: UseDelegate<SourceError> }]`, you now write two lines: `#[cgp_component(ErrorRaiser)]` followed by `#[derive_delegate(UseDelegate<SourceError>)]`. Multiple delegates that used to be a bracketed list become repeated attributes, one per line. This makes `#[cgp_component]` read like the other attribute-driven CGP macros, and it lets the same delegate-deriving logic be shared more uniformly across `#[cgp_type]` and `#[cgp_getter]`.

The third concept is a cleaner separation inside namespace tables between *defining* a namespace and *inheriting* from a parent. Creating the backing `__XComponents` struct is now the job of one function keyed on the `new` keyword, while wiring a namespace to its parent is the job of another keyed on the presence of a parent clause. The two concerns no longer share a code path.

## Structural changes

The path parser gains a dedicated type and a richer enum. A new `PathElementWithGenerics` type pairs a path element with its optional generic binder, and the `PathHead` enum is reshaped so that grouping is explicit: the old grouping variant is renamed `Nested`, and a new `Group(elements, tail)` variant carries a bracketed list plus the rest of the path. Both expansion routines — `into_paths` in the macro core and `path_head_to_prefix` in the macro lib — learn to walk the `Group` variant and emit the cartesian product. A new `Path!` proc-macro is exposed that parses a single path expression into its type form.

The `derive_delegate` plumbing is relocated, not just renamed. The parsing logic now lives in `CgpComponentAttributes`, which collects each `#[derive_delegate(...)]` occurrence into a vector; the old bracketed-list `Parse` impl and the `derive_delegate` key (with its duplicate-key guard) are deleted from the component-args types. The evaluation step reads the delegates from the parsed attributes instead of from the component args. Documentation, the test utilities README, and the affected component definitions across `cgp-error`, `cgp-type`, `cgp-handler`, and `cgp-run` are all migrated to the new form, and the handler components additionally gain explicit `#[prefix(@cgp.extra.handler in DefaultNamespace)]` annotations.

The namespace table is split along the seam described above. `build_namespace_struct` now emits the `__XComponents` struct whenever `new` is present, independent of any parent, and `build_parent_namespace_impl` returns only the inheritance impl. The `DelegateComponent` trait's parameter is renamed `Name → Key` to match the type-level-table framing, and macro-internal references to `Life`, `CanUseComponent`, and friends are now resolved through the `export_constructs!` table so generated code points at the canonical paths.

The test suite tracks these changes. A new `group.rs` snapshot test exercises grouped-path expansion end to end, the `multi_param` tests are simplified away from heavy snapshot wrapping toward direct macro use, and the namespace snapshots are updated to reflect that `new` namespaces now always emit their backing struct.

## Impacts

The user-facing migration is the most direct impact: any code using the brace-form `derive_delegate` must move to the standalone `#[derive_delegate(...)]` attribute. The brace key is now rejected with `unknown key derive_delegate`, so the change is a hard break for that syntax rather than a deprecation. All in-tree call sites are migrated, but downstream crates that used the old form will need the same edit.

Grouped paths reduce delegation boilerplate wherever the same provider serves many component-and-parameter combinations. The expansion is mechanical and equivalent to the longhand, so it introduces no new runtime behavior — the benefit is entirely in how much wiring a developer has to write and read.

The namespace refactor changes generated output in one visible way: a `new` namespace now always emits its `__XComponents` struct, even without a parent clause, which is why several snapshots grew a `pub struct __…Components;` line. This is consistent and intended, but it is a codegen difference worth noting for anyone comparing expanded output across versions.

A few sharp edges accompany the new flexibility, and they are worth keeping in mind. Specifying a parent namespace without `new` is no longer caught by a dedicated error; it now falls through to generated code that references an undefined struct, so the failure shows up as a confusing "cannot find type" message instead of a clear diagnostic. Grouped paths that reuse the same generic binder name across levels, or that contain an empty `[]` group, are not validated either — the former yields a duplicate-generic compile error and the latter silently expands to nothing. The new `Path!` macro currently parses only the single-path form and has no group support or tests. None of these block the feature, but they are the places where a user is most likely to hit an unhelpful error.
